### PR TITLE
WASH-454-auth-token-validation-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Export valid values for use by the integration tests:
 export E3DB_API_URL=https://dev.e3db.com
 export E3DB_API_KEY_ID=6f159d70096cedd0cadc9fb8f9e2a5e15d48e432a3ebfa2458e7788bc0684a99
 export E3DB_API_KEY_SECRET=2acf80b5707db78f477670f70c06a8a8888a507cc10aadc0ee4122166bd5649a
+export E3DB_CLIENT_ID=864e4b87-9eda-43fb-ae6d-d07d4275c73a
 ```
 * Recommend to use credentials and endpoint of dev
 * Go to http://console.dev.tozny.com

--- a/authClient/api.go
+++ b/authClient/api.go
@@ -1,0 +1,13 @@
+package authClient
+
+// ValidateTokenRequest represents a valid request to the auth service's /validate endpoint.
+type ValidateTokenRequest struct {
+    Token    string `json:"token"`    //The token to validate
+    Internal bool   `json:"internal"` //Whether this token belongs to an internal client
+}
+
+// ValidateTokenRequest represents a response to calling auth service's /validate endpoint.
+type ValidateTokenResponse struct {
+    ClientId string `json:"client_id"` //The client associated with this token
+    Valid    bool   `json:"valid"`     //Whether the token was valid
+}

--- a/authClient/authClient.go
+++ b/authClient/authClient.go
@@ -3,7 +3,9 @@
 package authClient
 
 import (
+    "bytes"
     "context"
+    "encoding/json"
     "fmt"
     "github.com/tozny/e3db-clients-go"
     "golang.org/x/oauth2"
@@ -15,8 +17,8 @@ const (
     AuthServiceBasePath = "v1/auth" //HTTP PATH prefix for calls to the auth service.
 )
 
-//E3DBAuthClient implements an http client for communication with an e3db auth service.
-type E3DBAuthClient struct {
+//E3dbAuthClient implements an http client for communication with an e3db auth service.
+type E3dbAuthClient struct {
     APIKey       string
     APISecret    string
     Host         string
@@ -25,19 +27,34 @@ type E3DBAuthClient struct {
 
 // GetToken attempts to retrieve and return a valid oauth2 token based on the clients
 // credentials, returning token and error(if any).
-func (c *E3DBAuthClient) GetToken(ctx context.Context) (*oauth2.Token, error) {
+func (c *E3dbAuthClient) GetToken(ctx context.Context) (*oauth2.Token, error) {
     return c.oauth2Helper.Token(ctx)
+}
+
+func (c *E3dbAuthClient) ValidateToken(ctx context.Context, params ValidateTokenRequest) (*ValidateTokenResponse, error) {
+    var result *ValidateTokenResponse
+    var buf bytes.Buffer
+    err := json.NewEncoder(&buf).Encode(&params)
+    if err != nil {
+        return result, err
+    }
+    request, err := http.NewRequest("POST", c.Host+"/"+AuthServiceBasePath+"/validate", &buf)
+    if err != nil {
+        return result, err
+    }
+    err = e3dbClients.MakeE3DBServiceCall(c, ctx, request, &result)
+    return result, err
 }
 
 // AuthHTTPClient returns an http client that can be used for
 // making authenticated requests to an e3db endpoint using the provided context.
-func (c *E3DBAuthClient) AuthHTTPClient(ctx context.Context) *http.Client {
+func (c *E3dbAuthClient) AuthHTTPClient(ctx context.Context) *http.Client {
     return c.oauth2Helper.Client(ctx)
 }
 
-// New returns a new E3DBAuthClient configured with the specified apiKey and apiSecret values.
-func New(config e3dbClients.ClientConfig) E3DBAuthClient {
-    return E3DBAuthClient{
+// New returns a new E3dbAuthClient configured with the specified apiKey and apiSecret values.
+func New(config e3dbClients.ClientConfig) E3dbAuthClient {
+    return E3dbAuthClient{
         APIKey:    config.APIKey,
         APISecret: config.APISecret,
         Host:      config.Host,

--- a/authClient/authClient_test.go
+++ b/authClient/authClient_test.go
@@ -7,7 +7,7 @@ import (
     "testing"
 )
 
-func TestNewReturnsE3DBAuthClientWithSpecifiedConfiguration(t *testing.T) {
+func TestNewReturnsE3dbAuthClientWithSpecifiedConfiguration(t *testing.T) {
     config := e3dbClients.ClientConfig{
         APIKey:    "MyApiKey",
         APISecret: "MyApiSecret",
@@ -51,5 +51,51 @@ func TestGetTokenSucceedsWhenClientCredentialsAreValid(t *testing.T) {
     _, err := e3dbAuth.GetToken(ctx)
     if err != nil {
         t.Error(err)
+    }
+}
+
+var e3dbClientId = os.Getenv("E3DB_CLIENT_ID")
+
+func TestValidateTokenReturnsValidResultsForValidToken(t *testing.T) {
+    config := e3dbClients.ClientConfig{
+        APIKey:    e3dbAPIKey,
+        APISecret: e3dbAPISecret,
+        Host:      e3dbBaseURL,
+    }
+    e3dbAuth := New(config)
+    ctx := context.TODO()
+    validToken, err := e3dbAuth.GetToken(ctx)
+    if err != nil {
+        t.Error(err)
+    }
+    validateTokenRequestParams := ValidateTokenRequest{Token: validToken.AccessToken}
+    response, err := e3dbAuth.ValidateToken(ctx, validateTokenRequestParams)
+    if err != nil {
+        t.Errorf("Error: %s calling ValidateToken", err)
+    }
+    if response.Valid != true {
+        t.Errorf("Expected token %v to be valid, got %v", validToken, response)
+    }
+    if response.ClientId != e3dbClientId {
+        t.Errorf("Expected token %v to belong to %v valid, got %v", validToken, e3dbClientId, response)
+
+    }
+}
+
+func TestValidateTokenReturnsValidResultsForInvalidToken(t *testing.T) {
+    config := e3dbClients.ClientConfig{
+        APIKey:    e3dbAPIKey,
+        APISecret: e3dbAPISecret,
+        Host:      e3dbBaseURL,
+    }
+    e3dbAuth := New(config)
+    ctx := context.TODO()
+    validateTokenRequestParams := ValidateTokenRequest{Token: "invalidToken.AccessToken"}
+    response, err := e3dbAuth.ValidateToken(ctx, validateTokenRequestParams)
+    if err != nil {
+        t.Errorf("Error: %s calling ValidateToken", err)
+    }
+    if response.Valid != false {
+        t.Errorf("Expected token to be invalid, got %v", response)
     }
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,82 @@
+package e3dbClients_test
+
+import (
+    "context"
+    "fmt"
+    "github.com/tozny/e3db-clients-go"
+    "github.com/tozny/e3db-clients-go/authClient"
+    "github.com/tozny/e3db-clients-go/pdsClient"
+    "github.com/tozny/e3db-go/v2"
+    "os"
+    "testing"
+    "time"
+)
+
+var e3dbBaseURL = os.Getenv("E3DB_API_URL")
+var e3dbAPIKey = os.Getenv("E3DB_API_KEY_ID")
+var e3dbAPISecret = os.Getenv("E3DB_API_KEY_SECRET")
+
+var ValidClientConfig = e3dbClients.ClientConfig{
+    APIKey:    e3dbAPIKey,
+    APISecret: e3dbAPISecret,
+    Host:      e3dbBaseURL,
+}
+
+func RegisterClient(email string) (pdsClient.E3dbPDSClient, authClient.E3dbAuthClient, string, error) {
+    var user pdsClient.E3dbPDSClient
+    var auth authClient.E3dbAuthClient
+    e3dbPDS := pdsClient.New(ValidClientConfig)
+    publicKey, privateKey, err := e3db.GenerateKeyPair()
+    if err != nil {
+        return user, auth, "", err
+    }
+    params := pdsClient.RegisterClientRequest{
+        Email:      email,
+        PublicKey:  pdsClient.ClientKey{Curve25519: publicKey},
+        PrivateKey: pdsClient.ClientKey{Curve25519: privateKey},
+    }
+    ctx := context.TODO()
+    resp, err := e3dbPDS.InternalRegisterClient(ctx, params)
+    if err != nil {
+        return user, auth, "", err
+    }
+    user = pdsClient.New(e3dbClients.ClientConfig{
+        APIKey:    resp.APIKeyID,
+        APISecret: resp.APISecret,
+        Host:      e3dbBaseURL,
+    })
+    auth = authClient.New(e3dbClients.ClientConfig{
+        APIKey:    resp.APIKeyID,
+        APISecret: resp.APISecret,
+        Host:      e3dbBaseURL,
+    })
+    return user, auth, resp.ClientID, err
+}
+
+var validPDSUser, validPDSAuthClient, validPDSUserID, _ = RegisterClient(fmt.Sprintf("test+main+%d@tozny.com", time.Now().Unix()))
+
+func TestValidateTokenReturnsValidResultsForValidExternalClientToken(t *testing.T) {
+    config := e3dbClients.ClientConfig{
+        APIKey:    e3dbAPIKey,
+        APISecret: e3dbAPISecret,
+        Host:      e3dbBaseURL,
+    }
+    e3dbAuth := authClient.New(config)
+    ctx := context.TODO()
+    userToken, err := validPDSAuthClient.GetToken(ctx)
+    if err != nil {
+        t.Errorf("Error: %v fetching token for user %v", err, validPDSAuthClient)
+    }
+    validateTokenRequestParams := authClient.ValidateTokenRequest{Token: userToken.AccessToken, Internal: true}
+    response, err := e3dbAuth.ValidateToken(ctx, validateTokenRequestParams)
+    if err != nil {
+        t.Errorf("Error: %s calling ValidateToken", err)
+    }
+    if response.Valid != true {
+        t.Errorf("Expected token to be valid, got %+v", response)
+    }
+    if response.ClientId != validPDSUserID {
+        t.Errorf("Expected token to belong to %v valid, got %+v", validPDSUserID, response)
+
+    }
+}

--- a/pdsClient/pdsClient.go
+++ b/pdsClient/pdsClient.go
@@ -14,12 +14,12 @@ const (
     PDSServiceBasePath = "v1/storage" //HTTP PATH prefix for calls to the Personal Data Storage service
 )
 
-//E3DBAuthClient implements an http client for communication with an e3db PDS service.
+//E3dbAuthClient implements an http client for communication with an e3db PDS service.
 type E3dbPDSClient struct {
     APIKey    string
     APISecret string
     Host      string
-    *authClient.E3DBAuthClient
+    *authClient.E3dbAuthClient
 }
 
 // InternalRegisterClient uses an internal(available only to locally running e3db instances) endpoint to register a client, returning the registered client and error (if any).
@@ -34,7 +34,7 @@ func (c *E3dbPDSClient) InternalRegisterClient(ctx context.Context, params Regis
     if err != nil {
         return result, err
     }
-    err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
+    err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
     return result, err
 }
 
@@ -50,7 +50,7 @@ func (c *E3dbPDSClient) PutAccessKey(ctx context.Context, params PutAccessKeyReq
     if err != nil {
         return result, err
     }
-    err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
+    err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
     return result, err
 }
 
@@ -67,7 +67,7 @@ func (c *E3dbPDSClient) WriteRecord(ctx context.Context, params WriteRecordReque
     if err != nil {
         return result, err
     }
-    err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
+    err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
     return result, err
 }
 
@@ -83,7 +83,7 @@ func (c *E3dbPDSClient) ListRecords(ctx context.Context, params ListRecordsReque
     if err != nil {
         return result, err
     }
-    err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
+    err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
     return result, err
 }
 
@@ -94,7 +94,7 @@ func (c *E3dbPDSClient) InternalGetRecord(ctx context.Context, recordID string) 
     if err != nil {
         return result, err
     }
-    err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
+    err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
     return result, err
 }
 

--- a/pdsClient/pdsClient_test.go
+++ b/pdsClient/pdsClient_test.go
@@ -45,7 +45,7 @@ func RegisterClient(email string) (E3dbPDSClient, string, error) {
     return user, resp.ClientID, err
 }
 
-var validPDSUser, validPDSUserID, _ = RegisterClient(fmt.Sprintf("test+%d@tozny.com", time.Now().Unix()))
+var validPDSUser, validPDSUserID, _ = RegisterClient(fmt.Sprintf("test+pdsClient+%d@tozny.com", time.Now().Unix()))
 
 var defaultPDSUserRecordType = "integration_tests"
 


### PR DESCRIPTION
- Add client code and integration test for calling auth service validate endpoint.
- Standardize capitalization of client naming.

Companion PR:
- https://github.com/tozny/e3db-auth/pull/26