### PR TITLE
Add New Client To Proxy User Request

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,54 +1,75 @@
 package e3dbClients
 
 import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "net/http"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 )
 
 // ClientConfig wraps configuration
 // needed by an e3db client
 type ClientConfig struct {
-    Host      string //Hostname of the e3db API to communicate with
-    APIKey    string //User/Client ID to use when communicating with the e3db API
-    APISecret string //User/Client secret to use when communicating with the e3db API
+	Host      string //Hostname of the e3db API to communicate with
+	APIKey    string //User/Client ID to use when communicating with the e3db API
+	APISecret string //User/Client secret to use when communicating with the e3db API
 }
 
 // E3DBHTTPAuthorizer implements the functionality needed to make
 // an authenticated call to an e3db endpoint.
 type E3DBHTTPAuthorizer interface {
-    AuthHTTPClient(ctx context.Context) *http.Client
+	AuthHTTPClient(ctx context.Context) *http.Client
 }
 
 // HTTPError wraps details of an HTTP error
 type HTTPError struct {
-    message    string
-    URL        string
-    StatusCode int
+	message    string
+	URL        string
+	StatusCode int
 }
 
 // Error implements the error interface for HTTPError.
 func (err *HTTPError) Error() string {
-    return err.message
+	return err.message
 }
 
 // MakeE3DBServiceCall attempts to call an e3db service by executing the provided request and deserializing the response into the provided result holder, returning error (if any).
 func MakeE3DBServiceCall(httpAuthorizer E3DBHTTPAuthorizer, ctx context.Context, request *http.Request, result interface{}) error {
-    client := httpAuthorizer.AuthHTTPClient(ctx)
-    response, err := client.Do(request)
-    if err != nil {
-        return err
-    }
-    defer response.Body.Close()
-    if !(response.StatusCode >= 200 && response.StatusCode <= 299) {
-        requestURL := request.URL.String()
-        return &HTTPError{
-            StatusCode: response.StatusCode,
-            URL:        requestURL,
-            message:    fmt.Sprintf("e3db: %s: server http error %d", requestURL, response.StatusCode),
-        }
-    }
-    err = json.NewDecoder(response.Body).Decode(&result)
-    return err
+	client := httpAuthorizer.AuthHTTPClient(ctx)
+	response, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if !(response.StatusCode >= 200 && response.StatusCode <= 299) {
+		requestURL := request.URL.String()
+		return &HTTPError{
+			StatusCode: response.StatusCode,
+			URL:        requestURL,
+			message:    fmt.Sprintf("e3db: %s: server http error %d", requestURL, response.StatusCode),
+		}
+	}
+	err = json.NewDecoder(response.Body).Decode(&result)
+	return err
+}
+
+// MakeProxiedUserCall attempts to call an e3db service using provided user auth token to authenticate request.
+func MakeProxiedUserCall(ctx context.Context, userAuthToken string, request *http.Request, result interface{}) error {
+	client := &http.Client{}
+	request.Header.Add("Authorization", "Bearer "+userAuthToken)
+	response, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if !(response.StatusCode >= 200 && response.StatusCode <= 299) {
+		requestURL := request.URL.String()
+		return &HTTPError{
+			StatusCode: response.StatusCode,
+			URL:        requestURL,
+			message:    fmt.Sprintf("e3db: %s: server http error %d", requestURL, response.StatusCode),
+		}
+	}
+	err = json.NewDecoder(response.Body).Decode(&result)
+	return err
 }

--- a/pdsClient/pdsClient.go
+++ b/pdsClient/pdsClient.go
@@ -25,15 +25,8 @@ type E3dbPDSClient struct {
 // InternalRegisterClient uses an internal(available only to locally running e3db instances) endpoint to register a client, returning the registered client and error (if any).
 func (c *E3dbPDSClient) InternalRegisterClient(ctx context.Context, params RegisterClientRequest) (*RegisterClientResponse, error) {
 	var result *RegisterClientResponse
-	var buf bytes.Buffer
-	err := json.NewEncoder(&buf).Encode(&params)
-	if err != nil {
-		return result, err
-	}
-	request, err := http.NewRequest("POST", c.Host+"/"+PDSServiceBasePath+"/clients", &buf)
-	if err != nil {
-		return result, err
-	}
+	path := c.Host + "/" + PDSServiceBasePath + "/clients"
+	request, err := createRequest("POST", path, params)
 	err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
 	return result, err
 }
@@ -41,15 +34,8 @@ func (c *E3dbPDSClient) InternalRegisterClient(ctx context.Context, params Regis
 // PutAccessKey attempts to set an access key that E3DB will enforce be used to write records of the specified type for the specified user, client, and writer, returning the response and error (if any).
 func (c *E3dbPDSClient) PutAccessKey(ctx context.Context, params PutAccessKeyRequest) (*PutAccessKeyResponse, error) {
 	var result *PutAccessKeyResponse
-	var buf bytes.Buffer
-	err := json.NewEncoder(&buf).Encode(&params)
-	if err != nil {
-		return result, err
-	}
-	request, err := http.NewRequest("PUT", c.Host+"/"+PDSServiceBasePath+"/access_keys"+fmt.Sprintf("/%s", params.WriterID)+fmt.Sprintf("/%s", params.UserID)+fmt.Sprintf("/%s", params.ReaderID)+fmt.Sprintf("/%s", params.RecordType), &buf)
-	if err != nil {
-		return result, err
-	}
+	path := c.Host + "/" + PDSServiceBasePath + "/access_keys" + fmt.Sprintf("/%s", params.WriterID) + fmt.Sprintf("/%s", params.UserID) + fmt.Sprintf("/%s", params.ReaderID) + fmt.Sprintf("/%s", params.RecordType)
+	request, err := createRequest("PUT", path, params)
 	err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
 	return result, err
 }
@@ -58,12 +44,8 @@ func (c *E3dbPDSClient) PutAccessKey(ctx context.Context, params PutAccessKeyReq
 // XXX: Data is not encrypted in this method, it is the caller's responsibility to ensure data is encrypted before sending to e3db.
 func (c *E3dbPDSClient) WriteRecord(ctx context.Context, params WriteRecordRequest) (*WriteRecordResponse, error) {
 	var result *WriteRecordResponse
-	var buf bytes.Buffer
-	err := json.NewEncoder(&buf).Encode(&params)
-	if err != nil {
-		return result, err
-	}
-	request, err := http.NewRequest("POST", c.Host+"/"+PDSServiceBasePath+"/records", &buf)
+	path := c.Host + "/" + PDSServiceBasePath + "/records"
+	request, err := createRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
@@ -72,14 +54,22 @@ func (c *E3dbPDSClient) WriteRecord(ctx context.Context, params WriteRecordReque
 }
 
 // ListRecords returns a list of records using any filters provided as params, and error (if any).
-func (c *E3dbPDSClient) ListRecords(ctx context.Context, authToken string, params ListRecordsRequest) (*ListRecordsResult, error) {
+func (c *E3dbPDSClient) ListRecords(ctx context.Context, params ListRecordsRequest) (*ListRecordsResult, error) {
 	var result *ListRecordsResult
-	var buf bytes.Buffer
-	err := json.NewEncoder(&buf).Encode(&params)
+	path := c.Host + "/" + PDSServiceBasePath + "/search"
+	request, err := createRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
-	request, err := http.NewRequest("POST", c.Host+"/"+PDSServiceBasePath+"/search", &buf)
+	err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
+	return result, err
+}
+
+// ProxyListRecords returns a list of records using any filters provided as params, and error (if any).
+func (c *E3dbPDSClient) ProxyListRecords(ctx context.Context, authToken string, params ListRecordsRequest) (*ListRecordsResult, error) {
+	var result *ListRecordsResult
+	path := c.Host + "/" + PDSServiceBasePath + "/search"
+	request, err := createRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
@@ -90,12 +80,25 @@ func (c *E3dbPDSClient) ListRecords(ctx context.Context, authToken string, param
 // InternalGetRecord attempts to get a record using an internal only e3db endpoint, returning fetched record and error (if any).
 func (c *E3dbPDSClient) InternalGetRecord(ctx context.Context, recordID string) (*InternalGetRecordResponse, error) {
 	var result *InternalGetRecordResponse
-	request, err := http.NewRequest("GET", c.Host+"/internal/"+PDSServiceBasePath+"/records/"+recordID, nil)
+	path := c.Host + "/internal/" + PDSServiceBasePath + "/records/" + recordID
+	request, err := createRequest("GET", path, nil)
 	if err != nil {
 		return result, err
 	}
 	err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
 	return result, err
+}
+
+// createListRecordsRequest isolates duplicate code in creating http search request.
+func createRequest(method string, path string, params interface{}) (*http.Request, error) {
+	var buf bytes.Buffer
+	var request *http.Request
+	err := json.NewEncoder(&buf).Encode(&params)
+	if err != nil {
+		return request, err
+	}
+	request, err = http.NewRequest(method, path, &buf)
+	return request, err
 }
 
 // New returns a new E3dbPDSClient configured with the specified apiKey and apiSecret values.

--- a/pdsClient/pdsClient.go
+++ b/pdsClient/pdsClient.go
@@ -1,110 +1,110 @@
 package pdsClient
 
 import (
-    "bytes"
-    "context"
-    "encoding/json"
-    "fmt"
-    "github.com/tozny/e3db-clients-go"
-    "github.com/tozny/e3db-clients-go/authClient"
-    "net/http"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/tozny/e3db-clients-go"
+	"github.com/tozny/e3db-clients-go/authClient"
+	"net/http"
 )
 
 const (
-    PDSServiceBasePath = "v1/storage" //HTTP PATH prefix for calls to the Personal Data Storage service
+	PDSServiceBasePath = "v1/storage" //HTTP PATH prefix for calls to the Personal Data Storage service
 )
 
 //E3DBAuthClient implements an http client for communication with an e3db PDS service.
 type E3dbPDSClient struct {
-    APIKey    string
-    APISecret string
-    Host      string
-    *authClient.E3DBAuthClient
+	APIKey    string
+	APISecret string
+	Host      string
+	*authClient.E3DBAuthClient
 }
 
 // InternalRegisterClient uses an internal(available only to locally running e3db instances) endpoint to register a client, returning the registered client and error (if any).
 func (c *E3dbPDSClient) InternalRegisterClient(ctx context.Context, params RegisterClientRequest) (*RegisterClientResponse, error) {
-    var result *RegisterClientResponse
-    var buf bytes.Buffer
-    err := json.NewEncoder(&buf).Encode(&params)
-    if err != nil {
-        return result, err
-    }
-    request, err := http.NewRequest("POST", c.Host+"/"+PDSServiceBasePath+"/clients", &buf)
-    if err != nil {
-        return result, err
-    }
-    err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
-    return result, err
+	var result *RegisterClientResponse
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(&params)
+	if err != nil {
+		return result, err
+	}
+	request, err := http.NewRequest("POST", c.Host+"/"+PDSServiceBasePath+"/clients", &buf)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
+	return result, err
 }
 
 // PutAccessKey attempts to set an access key that E3DB will enforce be used to write records of the specified type for the specified user, client, and writer, returning the response and error (if any).
 func (c *E3dbPDSClient) PutAccessKey(ctx context.Context, params PutAccessKeyRequest) (*PutAccessKeyResponse, error) {
-    var result *PutAccessKeyResponse
-    var buf bytes.Buffer
-    err := json.NewEncoder(&buf).Encode(&params)
-    if err != nil {
-        return result, err
-    }
-    request, err := http.NewRequest("PUT", c.Host+"/"+PDSServiceBasePath+"/access_keys"+fmt.Sprintf("/%s", params.WriterID)+fmt.Sprintf("/%s", params.UserID)+fmt.Sprintf("/%s", params.ReaderID)+fmt.Sprintf("/%s", params.RecordType), &buf)
-    if err != nil {
-        return result, err
-    }
-    err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
-    return result, err
+	var result *PutAccessKeyResponse
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(&params)
+	if err != nil {
+		return result, err
+	}
+	request, err := http.NewRequest("PUT", c.Host+"/"+PDSServiceBasePath+"/access_keys"+fmt.Sprintf("/%s", params.WriterID)+fmt.Sprintf("/%s", params.UserID)+fmt.Sprintf("/%s", params.ReaderID)+fmt.Sprintf("/%s", params.RecordType), &buf)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
+	return result, err
 }
 
 // WriteRecord attempts to store a record in e3db, returning stored record and error (if any).
 // XXX: Data is not encrypted in this method, it is the caller's responsibility to ensure data is encrypted before sending to e3db.
 func (c *E3dbPDSClient) WriteRecord(ctx context.Context, params WriteRecordRequest) (*WriteRecordResponse, error) {
-    var result *WriteRecordResponse
-    var buf bytes.Buffer
-    err := json.NewEncoder(&buf).Encode(&params)
-    if err != nil {
-        return result, err
-    }
-    request, err := http.NewRequest("POST", c.Host+"/"+PDSServiceBasePath+"/records", &buf)
-    if err != nil {
-        return result, err
-    }
-    err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
-    return result, err
+	var result *WriteRecordResponse
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(&params)
+	if err != nil {
+		return result, err
+	}
+	request, err := http.NewRequest("POST", c.Host+"/"+PDSServiceBasePath+"/records", &buf)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
+	return result, err
 }
 
 // ListRecords returns a list of records using any filters provided as params, and error (if any).
-func (c *E3dbPDSClient) ListRecords(ctx context.Context, params ListRecordsRequest) (*ListRecordsResult, error) {
-    var result *ListRecordsResult
-    var buf bytes.Buffer
-    err := json.NewEncoder(&buf).Encode(&params)
-    if err != nil {
-        return result, err
-    }
-    request, err := http.NewRequest("POST", c.Host+"/"+PDSServiceBasePath+"/search", &buf)
-    if err != nil {
-        return result, err
-    }
-    err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
-    return result, err
+func (c *E3dbPDSClient) ListRecords(ctx context.Context, authToken string, params ListRecordsRequest) (*ListRecordsResult, error) {
+	var result *ListRecordsResult
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(&params)
+	if err != nil {
+		return result, err
+	}
+	request, err := http.NewRequest("POST", c.Host+"/"+PDSServiceBasePath+"/search", &buf)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeProxiedUserCall(ctx, authToken, request, &result)
+	return result, err
 }
 
 // InternalGetRecord attempts to get a record using an internal only e3db endpoint, returning fetched record and error (if any).
 func (c *E3dbPDSClient) InternalGetRecord(ctx context.Context, recordID string) (*InternalGetRecordResponse, error) {
-    var result *InternalGetRecordResponse
-    request, err := http.NewRequest("GET", c.Host+"/internal/"+PDSServiceBasePath+"/records/"+recordID, nil)
-    if err != nil {
-        return result, err
-    }
-    err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
-    return result, err
+	var result *InternalGetRecordResponse
+	request, err := http.NewRequest("GET", c.Host+"/internal/"+PDSServiceBasePath+"/records/"+recordID, nil)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3DBAuthClient, ctx, request, &result)
+	return result, err
 }
 
 // New returns a new E3dbPDSClient configured with the specified apiKey and apiSecret values.
 func New(config e3dbClients.ClientConfig) E3dbPDSClient {
-    authService := authClient.New(config)
-    return E3dbPDSClient{
-        config.APIKey,
-        config.APISecret,
-        config.Host,
-        &authService,
-    }
+	authService := authClient.New(config)
+	return E3dbPDSClient{
+		config.APIKey,
+		config.APISecret,
+		config.Host,
+		&authService,
+	}
 }

--- a/pdsClient/pdsClient_test.go
+++ b/pdsClient/pdsClient_test.go
@@ -1,13 +1,13 @@
 package pdsClient
 
 import (
-    "context"
-    "fmt"
-    "github.com/tozny/e3db-clients-go"
-    "github.com/tozny/e3db-go/v2"
-    "os"
-    "testing"
-    "time"
+	"context"
+	"fmt"
+	"github.com/tozny/e3db-clients-go"
+	"github.com/tozny/e3db-go/v2"
+	"os"
+	"testing"
+	"time"
 )
 
 var e3dbBaseURL = os.Getenv("E3DB_API_URL")
@@ -15,34 +15,34 @@ var e3dbAPIKey = os.Getenv("E3DB_API_KEY_ID")
 var e3dbAPISecret = os.Getenv("E3DB_API_KEY_SECRET")
 
 var ValidClientConfig = e3dbClients.ClientConfig{
-    APIKey:    e3dbAPIKey,
-    APISecret: e3dbAPISecret,
-    Host:      e3dbBaseURL,
+	APIKey:    e3dbAPIKey,
+	APISecret: e3dbAPISecret,
+	Host:      e3dbBaseURL,
 }
 
 func RegisterClient(email string) (E3dbPDSClient, string, error) {
-    var user E3dbPDSClient
-    e3dbPDS := New(ValidClientConfig)
-    publicKey, privateKey, err := e3db.GenerateKeyPair()
-    if err != nil {
-        return user, "", err
-    }
-    params := RegisterClientRequest{
-        Email:      email,
-        PublicKey:  ClientKey{publicKey},
-        PrivateKey: ClientKey{privateKey},
-    }
-    ctx := context.TODO()
-    resp, err := e3dbPDS.InternalRegisterClient(ctx, params)
-    if err != nil {
-        return user, "", err
-    }
-    user = New(e3dbClients.ClientConfig{
-        APIKey:    resp.APIKeyID,
-        APISecret: resp.APISecret,
-        Host:      e3dbBaseURL,
-    })
-    return user, resp.ClientID, err
+	var user E3dbPDSClient
+	e3dbPDS := New(ValidClientConfig)
+	publicKey, privateKey, err := e3db.GenerateKeyPair()
+	if err != nil {
+		return user, "", err
+	}
+	params := RegisterClientRequest{
+		Email:      email,
+		PublicKey:  ClientKey{publicKey},
+		PrivateKey: ClientKey{privateKey},
+	}
+	ctx := context.TODO()
+	resp, err := e3dbPDS.InternalRegisterClient(ctx, params)
+	if err != nil {
+		return user, "", err
+	}
+	user = New(e3dbClients.ClientConfig{
+		APIKey:    resp.APIKeyID,
+		APISecret: resp.APISecret,
+		Host:      e3dbBaseURL,
+	})
+	return user, resp.ClientID, err
 }
 
 var validPDSUser, validPDSUserID, _ = RegisterClient(fmt.Sprintf("test+%d@tozny.com", time.Now().Unix()))
@@ -50,98 +50,99 @@ var validPDSUser, validPDSUserID, _ = RegisterClient(fmt.Sprintf("test+%d@tozny.
 var defaultPDSUserRecordType = "integration_tests"
 
 func MakeClientWriterForRecordType(pdsUser E3dbPDSClient, clientID string, recordType string) (string, error) {
-    ctx := context.TODO()
-    putEAKParams := PutAccessKeyRequest{
-        WriterID:           clientID,
-        UserID:             clientID,
-        ReaderID:           clientID,
-        RecordType:         recordType,
-        EncryptedAccessKey: "SOMERANDOMNPOTENTIALLYNONVALIDKEY",
-    }
-    resp, err := pdsUser.PutAccessKey(ctx, putEAKParams)
-    return resp.EncryptedAccessKey, err
+	ctx := context.TODO()
+	putEAKParams := PutAccessKeyRequest{
+		WriterID:           clientID,
+		UserID:             clientID,
+		ReaderID:           clientID,
+		RecordType:         recordType,
+		EncryptedAccessKey: "SOMERANDOMNPOTENTIALLYNONVALIDKEY",
+	}
+	resp, err := pdsUser.PutAccessKey(ctx, putEAKParams)
+	return resp.EncryptedAccessKey, err
 }
 
 var validPDSEncryptedAccessKey, _ = MakeClientWriterForRecordType(validPDSUser, validPDSUserID, defaultPDSUserRecordType)
 
 func TestListRecordsSucceedsWithValidClientCredentials(t *testing.T) {
-    var createdRecordIds []string
-    ctx := context.TODO()
-    // Create two records with that client
-    for i := 0; i < 2; i++ {
-        data := map[string]string{"data": "unencrypted"}
-        recordToWrite := WriteRecordRequest{
-            Data: data,
-            Metadata: Meta{
-                Type:     defaultPDSUserRecordType,
-                WriterID: validPDSUserID,
-                UserID:   validPDSUserID,
-                Plain:    map[string]string{"key": "value"},
-            },
-        }
-        record, err := validPDSUser.WriteRecord(ctx, recordToWrite)
-        if err != nil {
-            t.Error(err)
-        }
-        createdRecordIds = append(createdRecordIds, record.Metadata.RecordID)
-    }
-    // List records and verify the created records are present
-    params := ListRecordsRequest{
-        Count:             50,
-        IncludeAllWriters: true,
-    }
-    listedRecords, err := validPDSUser.ListRecords(ctx, params)
-    if err != nil {
-        t.Error(err)
-    }
-    for _, id := range createdRecordIds {
-        var match bool
-        for _, listedRecord := range listedRecords.Results {
-            if id == listedRecord.Metadata.RecordID {
-                match = true
-                break
-            }
-        }
-        if !match {
-            t.Errorf("Failed to find created record with id %s in response %v\n", id, listedRecords)
-        }
-    }
+	var createdRecordIds []string
+	ctx := context.TODO()
+	// Create two records with that client
+	for i := 0; i < 2; i++ {
+		data := map[string]string{"data": "unencrypted"}
+		recordToWrite := WriteRecordRequest{
+			Data: data,
+			Metadata: Meta{
+				Type:     defaultPDSUserRecordType,
+				WriterID: validPDSUserID,
+				UserID:   validPDSUserID,
+				Plain:    map[string]string{"key": "value"},
+			},
+		}
+		record, err := validPDSUser.WriteRecord(ctx, recordToWrite)
+		if err != nil {
+			t.Error(err)
+		}
+		createdRecordIds = append(createdRecordIds, record.Metadata.RecordID)
+	}
+	// List records and verify the created records are present
+	params := ListRecordsRequest{
+		Count:             50,
+		IncludeAllWriters: true,
+	}
+	tok, err := validPDSUser.GetToken(ctx)
+	listedRecords, err := validPDSUser.ListRecords(ctx, tok.AccessToken, params)
+	if err != nil {
+		t.Error(err)
+	}
+	for _, id := range createdRecordIds {
+		var match bool
+		for _, listedRecord := range listedRecords.Results {
+			if id == listedRecord.Metadata.RecordID {
+				match = true
+				break
+			}
+		}
+		if !match {
+			t.Errorf("Failed to find created record with id %s in response %v\n", id, listedRecords)
+		}
+	}
 }
 
 func TestInternalGetRecordSucceedsWithValidClientCredentials(t *testing.T) {
-    ctx := context.TODO()
-    // Create record with e3db external client
-    data := map[string]string{"data": "unencrypted"}
-    recordToWrite := WriteRecordRequest{
-        Data: data,
-        Metadata: Meta{
-            Type:     defaultPDSUserRecordType,
-            WriterID: validPDSUserID,
-            UserID:   validPDSUserID,
-            Plain:    map[string]string{"key": "value"},
-        },
-    }
-    createdRecord, err := validPDSUser.WriteRecord(ctx, recordToWrite)
-    if err != nil {
-        t.Error(err)
-    }
-    // Fetch that record with e3db internal client
-    e3dbPDS := New(ValidClientConfig)
+	ctx := context.TODO()
+	// Create record with e3db external client
+	data := map[string]string{"data": "unencrypted"}
+	recordToWrite := WriteRecordRequest{
+		Data: data,
+		Metadata: Meta{
+			Type:     defaultPDSUserRecordType,
+			WriterID: validPDSUserID,
+			UserID:   validPDSUserID,
+			Plain:    map[string]string{"key": "value"},
+		},
+	}
+	createdRecord, err := validPDSUser.WriteRecord(ctx, recordToWrite)
+	if err != nil {
+		t.Error(err)
+	}
+	// Fetch that record with e3db internal client
+	e3dbPDS := New(ValidClientConfig)
 
-    resp, err := e3dbPDS.InternalGetRecord(ctx, createdRecord.Metadata.RecordID)
-    if err != nil {
-        t.Error(err)
-    }
-    for createdKey, createdValue := range recordToWrite.Metadata.Plain {
-        var match bool
-        for retrievedKey, retrievedValue := range resp.Metadata.Plain {
-            if retrievedKey == createdKey && retrievedValue == createdValue {
-                match = true
-                break
-            }
-            if !match {
-                t.Logf("Returned record did not match previously created record, missing plain object %s=>%s", createdKey, createdValue)
-            }
-        }
-    }
+	resp, err := e3dbPDS.InternalGetRecord(ctx, createdRecord.Metadata.RecordID)
+	if err != nil {
+		t.Error(err)
+	}
+	for createdKey, createdValue := range recordToWrite.Metadata.Plain {
+		var match bool
+		for retrievedKey, retrievedValue := range resp.Metadata.Plain {
+			if retrievedKey == createdKey && retrievedValue == createdValue {
+				match = true
+				break
+			}
+			if !match {
+				t.Logf("Returned record did not match previously created record, missing plain object %s=>%s", createdKey, createdValue)
+			}
+		}
+	}
 }


### PR DESCRIPTION
This is to add a new method that proxies user calls to PDS for the Executer it takes a bearer token and manually constructs the authorization header for the request.

Companion PR to WASH-501 on e3dbsearchservice, waiting on merge of WASH-500 to make PR for that.