### PR TITLE
Add InternalAllowedReads method to pds client

### DIFF
--- a/pdsClient/api.go
+++ b/pdsClient/api.go
@@ -4,6 +4,23 @@ import (
 	"time"
 )
 
+// InternalAllowedReadsRequest represents a valid request to the AllowedReads endpoint
+type InternalAllowedReadsRequest struct {
+	ReaderId string
+}
+
+// InternalAllowedReadsResponse represents a response from calling the AllowedReads endpoint
+type InternalAllowedReadsResponse struct {
+	AllowedReads []AllowedRead `json:"allowed_reads"`
+}
+
+// AllowedRead represents an access policy that allows an e3db user to read records of a specified type written and owned by specified users.
+type AllowedRead struct {
+	UserId      string `json:"user_id"`
+	WriterId    string `json:"writer_id"`
+	ContentType string `json:"content_type"`
+}
+
 // RegisterClientRequest represents a request to register a client.
 type RegisterClientRequest struct {
 	Email      string    `json:"email"`
@@ -72,7 +89,9 @@ type Meta struct {
 	Created      time.Time         `json:"created"`
 	LastModified time.Time         `json:"last_modified"`
 	Version      string            `json:"version,omitempty"`
-	FileMeta     FileMeta          `json:"file_meta,omitempty"`
+	// Certain pds endpoints such as WriteRecord return 400 Bad Request if this key is present in the JSON
+	// https://www.sohamkamani.com/blog/golang/2018-07-19-golang-omitempty/
+	FileMeta *FileMeta `json:"file_meta,omitempty"`
 }
 
 // FileMeta contains meta-information about files associated with E3DB Large File Records,

--- a/pdsClient/pdsClient.go
+++ b/pdsClient/pdsClient.go
@@ -22,6 +22,18 @@ type E3dbPDSClient struct {
 	*authClient.E3dbAuthClient
 }
 
+// InternalAllowedReads attempts to retrieve the list of AllowedRead policies for other users records for the given reader using an internal only e3db endpoint, returning InternalAllowedReadsResponse(which may or may not be empty of AllowedRead policies) and error (if any).
+func (c *E3dbPDSClient) InternalAllowedReads(ctx context.Context, readerID string) (*InternalAllowedReadsResponse, error) {
+	var result *InternalAllowedReadsResponse
+	path := c.Host + "/internal/" + PDSServiceBasePath + "/allowed_reads/" + readerID
+	request, err := createRequest("GET", path, nil)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
+	return result, err
+}
+
 // InternalRegisterClient uses an internal(available only to locally running e3db instances) endpoint to register a client, returning the registered client and error (if any).
 func (c *E3dbPDSClient) InternalRegisterClient(ctx context.Context, params RegisterClientRequest) (*RegisterClientResponse, error) {
 	var result *RegisterClientResponse
@@ -89,7 +101,7 @@ func (c *E3dbPDSClient) InternalGetRecord(ctx context.Context, recordID string) 
 	return result, err
 }
 
-// createListRecordsRequest isolates duplicate code in creating http search request.
+// createRequest isolates duplicate code in creating http search request.
 func createRequest(method string, path string, params interface{}) (*http.Request, error) {
 	var buf bytes.Buffer
 	var request *http.Request

--- a/pdsClient/pdsClient_test.go
+++ b/pdsClient/pdsClient_test.go
@@ -154,3 +154,12 @@ func TestInternalGetRecordSucceedsWithValidClientCredentials(t *testing.T) {
 		}
 	}
 }
+
+func TestInternalAllowedReadReturnsValidResponse(t *testing.T) {
+	ctx := context.TODO()
+	readerId := "3a0649b8-4e4c-4cd0-b909-1179c4d74d42"
+	_, err := e3dbPDS.InternalAllowedReads(ctx, readerId)
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
- Add InternalAllowedReads method to pds client, tests. 
- Update Record struct to work with all PDS endpoints.