### PR TITLE
Add e3db go client methods for sharing records between clients and ge…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/tozny/e3db-clients-go
 
 require (
+	github.com/google/uuid v1.1.0
 	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/tozny/e3db-go/v2 v2.1.1
 	golang.org/x/net v0.0.0-20181220203305-927f97764cc3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/uuid v1.1.0 h1:Jf4mxPC/ziBnoPIdpQdPJ9OeiomAUHLvxmPRSPH9m4s=
+github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/jawher/mow.cli v1.0.4/go.mod h1:5hQj2V8g+qYmLUVWqu4Wuja1pI57M83EChYLVZ0sMKk=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/main.go
+++ b/main.go
@@ -60,6 +60,11 @@ func makeServiceCall(client *http.Client, request *http.Request, result interfac
 			message:    fmt.Sprintf("e3db: %s: server http error %d", requestURL, response.StatusCode),
 		}
 	}
+	// If no result is expected, don't attempt to decode a potentially
+	// empty response stream and avoid incurring EOF errors
+	if result == nil {
+		return err
+	}
 	err = json.NewDecoder(response.Body).Decode(&result)
 	return err
 }

--- a/pdsClient/api.go
+++ b/pdsClient/api.go
@@ -4,9 +4,19 @@ import (
 	"time"
 )
 
+// ShareRecordsRequest wraps the needed parameters
+// to share records of a specified type from one
+// user to another
+type ShareRecordsRequest struct {
+	UserID     string
+	WriterID   string
+	ReaderID   string
+	RecordType string
+}
+
 // InternalAllowedReadsRequest represents a valid request to the AllowedReads endpoint
 type InternalAllowedReadsRequest struct {
-	ReaderId string
+	ReaderID string
 }
 
 // InternalAllowedReadsResponse represents a response from calling the AllowedReads endpoint
@@ -16,8 +26,8 @@ type InternalAllowedReadsResponse struct {
 
 // AllowedRead represents an access policy that allows an e3db user to read records of a specified type written and owned by specified users.
 type AllowedRead struct {
-	UserId      string `json:"user_id"`
-	WriterId    string `json:"writer_id"`
+	UserID      string `json:"user_id"`
+	WriterID    string `json:"writer_id"`
 	ContentType string `json:"content_type"`
 }
 
@@ -66,7 +76,7 @@ type WriteRecordResponse = Record
 
 // ListRecordsRequest represents a valid ListRecord call to the PDS service.
 type ListRecordsRequest struct {
-	Count       int  `json:"count"`                  //The maximum number of records to return.
+	Count       int  `json:"count,omitempty"`        //The maximum number of records to return.
 	IncludeData bool `json:"include_data,omitempty"` //If true, include record data with results.
 
 	WriterIDs         []string          `json:"writer_ids,omitempty"`    //If not empty, limit results to records written by the given set of IDs.
@@ -109,6 +119,17 @@ type GetEAKResponse struct {
 	EAK                 string    `json:"eak"`
 	AuthorizerID        string    `json:"authorizer_id"`
 	AuthorizerPublicKey ClientKey `json:"authorizer_public_key"`
+}
+
+// GetAccessKeyResponse contains the api representation of fetching an encrypted access key.
+type GetAccessKeyResponse = GetEAKResponse
+
+// GetAccessKeyRequest represents a request to get an access key from e3db.
+type GetAccessKeyRequest struct {
+	WriterID   string
+	UserID     string
+	ReaderID   string
+	RecordType string
 }
 
 // ClientKey contains a cryptographic key for use in client operations.

--- a/pdsClient/pdsClient.go
+++ b/pdsClient/pdsClient.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/tozny/e3db-clients-go"
 	"github.com/tozny/e3db-clients-go/authClient"
@@ -20,6 +21,70 @@ type E3dbPDSClient struct {
 	APISecret string
 	Host      string
 	*authClient.E3dbAuthClient
+}
+
+// readPolicy wraps an e3db API object
+// for read access to records
+type readPolicy struct {
+	Read map[string]interface{} `json:"read"`
+}
+
+// allowReadPolicy wraps an e3db API object granting read access to records
+type allowReadPolicy struct {
+	Allow []readPolicy `json:"allow"`
+}
+
+// / Share attempts to grants another e3db client permission to read records of the
+// specified record type, returning error (if any).
+func (c *E3dbPDSClient) ShareRecords(ctx context.Context, params ShareRecordsRequest) error {
+	// Get the current encrypted access key
+	// used to write records of this type by
+	// the client specified in params
+	getAccessKeyResponse, err := c.GetAccessKey(ctx, GetAccessKeyRequest{
+		WriterID:   params.WriterID,
+		UserID:     params.UserID,
+		ReaderID:   params.UserID,
+		RecordType: params.RecordType,
+	})
+	if err != nil {
+		return err
+	}
+	encryptedAccessKey := getAccessKeyResponse.EAK
+	if encryptedAccessKey == "" {
+		return errors.New("no applicable records exist to share")
+	}
+	// TODO: Decrypt this key
+	// TODO: using the decrypted version of
+	// encryptedAccessKey and the public key of
+	// the reader specified in params,
+	// create an encrypted access key that
+	// the reader can decrypt
+	// Put the encrypted access key for the reader
+	_, err = c.PutAccessKey(ctx, PutAccessKeyRequest{
+		UserID:             params.UserID,
+		WriterID:           params.WriterID,
+		ReaderID:           params.ReaderID,
+		RecordType:         params.RecordType,
+		EncryptedAccessKey: encryptedAccessKey,
+	})
+	if err != nil {
+		return err
+	}
+	path := c.Host + "/" + PDSServiceBasePath + "/policy/" + params.UserID + "/" + params.WriterID + "/" + params.ReaderID + "/" + params.RecordType
+	// Create a policy to apply for the reader to be allowed to read records of type specified in params
+	sharePolicy := allowReadPolicy{
+		Allow: []readPolicy{
+			readPolicy{
+				Read: make(map[string]interface{}),
+			},
+		},
+	}
+	request, err := createRequest("PUT", path, sharePolicy)
+	if err != nil {
+		return err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, nil)
+	return err
 }
 
 // InternalAllowedReads attempts to retrieve the list of AllowedRead policies for other users records for the given reader using an internal only e3db endpoint, returning InternalAllowedReadsResponse(which may or may not be empty of AllowedRead policies) and error (if any).
@@ -48,6 +113,15 @@ func (c *E3dbPDSClient) PutAccessKey(ctx context.Context, params PutAccessKeyReq
 	var result *PutAccessKeyResponse
 	path := c.Host + "/" + PDSServiceBasePath + "/access_keys" + fmt.Sprintf("/%s", params.WriterID) + fmt.Sprintf("/%s", params.UserID) + fmt.Sprintf("/%s", params.ReaderID) + fmt.Sprintf("/%s", params.RecordType)
 	request, err := createRequest("PUT", path, params)
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
+	return result, err
+}
+
+// GetAccessKey attempts to get an access key stored in E3DB returning the response and error (if any).
+func (c *E3dbPDSClient) GetAccessKey(ctx context.Context, params GetAccessKeyRequest) (*GetAccessKeyResponse, error) {
+	var result *GetAccessKeyResponse
+	path := c.Host + "/" + PDSServiceBasePath + "/access_keys" + fmt.Sprintf("/%s", params.WriterID) + fmt.Sprintf("/%s", params.UserID) + fmt.Sprintf("/%s", params.ReaderID) + fmt.Sprintf("/%s", params.RecordType)
+	request, err := createRequest("GET", path, params)
 	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
 	return result, err
 }


### PR DESCRIPTION
- Add e3db go client methods for sharing records between clients and getting access keys.
- Tests.
# TODO
- Convert all naming of FieldId's to FieldID