### PR TITLE
[WIP] Call internal modified records endpoint

### DIFF
--- a/pdsClient/api.go
+++ b/pdsClient/api.go
@@ -31,6 +31,24 @@ type AllowedRead struct {
 	ContentType string `json:"content_type"`
 }
 
+// InternalModifiedSearchRequest represents a valid request to internal records search for getting modified records
+type InternalModifiedSearchRequest struct {
+	NextToken int                   `json:"next_token"`
+	Range     InternalModifiedRange `json:"range"`
+}
+
+// InternalModifiedSearchResponse represents a response from calling the internal records search endpoint
+type InternalModifiedSearchResponse struct {
+	NextToken int      `json:"next_token"`
+	Records   []Record `json:"records"`
+}
+
+// InternalModifiedRange represents the range parameter for the internal modified search request
+type InternalModifiedRange struct {
+	After  time.Time `json:"modified_after"`
+	Before time.Time `json:"modified_before"`
+}
+
 // RegisterClientRequest represents a request to register a client.
 type RegisterClientRequest struct {
 	Email      string    `json:"email"`

--- a/pdsClient/pdsClient.go
+++ b/pdsClient/pdsClient.go
@@ -105,6 +105,15 @@ func (c *E3dbPDSClient) InternalRegisterClient(ctx context.Context, params Regis
 	return result, err
 }
 
+// InternalModifiedSearch uses and internal endpoint to search for modified records within a time range
+func (c *E3dbPDSClient) InternalModifiedSearch(ctx context.Context, params InternalModifiedSearchRequest) (*InternalModifiedSearchResponse, error) {
+	var result *InternalModifiedSearchResponse
+	path := c.Host + "/internal/" + PDSServiceBasePath + "/records/search"
+	request, err := e3dbClients.CreateRequest("POST", path, params)
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
+	return result, err
+}
+
 // PutAccessKey attempts to set an access key that E3DB will enforce be used to write records of the specified type for the specified user, client, and writer, returning the response and error (if any).
 func (c *E3dbPDSClient) PutAccessKey(ctx context.Context, params PutAccessKeyRequest) (*PutAccessKeyResponse, error) {
 	var result *PutAccessKeyResponse

--- a/pdsClient/pdsClient.go
+++ b/pdsClient/pdsClient.go
@@ -108,7 +108,7 @@ func (c *E3dbPDSClient) InternalRegisterClient(ctx context.Context, params Regis
 // InternalModifiedSearch uses and internal endpoint to search for modified records within a time range
 func (c *E3dbPDSClient) InternalModifiedSearch(ctx context.Context, params InternalModifiedSearchRequest) (*InternalModifiedSearchResponse, error) {
 	var result *InternalModifiedSearchResponse
-	path := c.Host + "/internal/" + PDSServiceBasePath + "/records/search"
+	path := c.Host + "/internal/" + PDSServiceBasePath + "/search"
 	request, err := e3dbClients.CreateRequest("POST", path, params)
 	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
 	return result, err

--- a/pdsClient/pdsClient_test.go
+++ b/pdsClient/pdsClient_test.go
@@ -61,6 +61,9 @@ func MakeClientWriterForRecordType(pdsUser E3dbPDSClient, clientID string, recor
 		EncryptedAccessKey: "SOMERANDOMNPOTENTIALLYNONVALIDKEY",
 	}
 	resp, err := pdsUser.PutAccessKey(ctx, putEAKParams)
+	if err != nil {
+		fmt.Printf("Error placing access key %s\n", err)
+	}
 	return resp.EncryptedAccessKey, err
 }
 
@@ -299,9 +302,9 @@ func TestFindModifiedRecords(t *testing.T) {
 			Before: endTime,
 		},
 	}
-	modifiedResponse, err := validPDSUser.InternalModifiedSearch(ctx, modifiedRecordRequest)
+	modifiedResponse, err := e3dbPDS.InternalModifiedSearch(ctx, modifiedRecordRequest)
 	if err != nil {
-		t.Errorf("Error getting modified records %s\n", err)
+		t.Fatalf("Error getting modified records %s\n", err)
 	}
 	found := false
 	for _, record := range modifiedResponse.Records {


### PR DESCRIPTION
Work in progress.

Depends on https://github.com/tozny/pds-service/pull/138 to function, and will be tested once that is merged into PDS.
 
More tests for value:
- if the endpoint allows removing one time range (all records modified after this time)
- test actual modified record, not just creation, is returned by endpoint