### PR TITLE
Reuse e3db auth token as long as it is valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ make build
 will lint and build the projects source code.
 
 ## Test
-Export valid values for use by the integration tests:
+Export valid values for use by the integration tests
+
 ```
-export E3DB_API_URL=https://dev.e3db.com
-export E3DB_API_KEY_ID=6f159d70096cedd0cadc9fb8f9e2a5e15d48e432a3ebfa2458e7788bc0684a99
-export E3DB_API_KEY_SECRET=2acf80b5707db78f477670f70c06a8a8888a507cc10aadc0ee4122166bd5649a
+export E3DB_API_URL=http://local.e3db.com
+export E3DB_API_KEY_ID=1d66c182779e47714cd957d4760a121580598d68e064c948e5887662c197538b
+export E3DB_API_KEY_SECRET=aaadbd1cc72870e6bd41befa1273b4513d0d1fa04fb913257eec6158b6a35d75
 export E3DB_CLIENT_ID=864e4b87-9eda-43fb-ae6d-d07d4275c73a
 export E3DB_SEARCH_INDEXER_HOST=http://localhost:9000
 ```
@@ -30,6 +31,8 @@ Then run:
 make test
 ```
 to execute integration tests using the code in this project to make API calls against the specified e3db instance.
+
+Sample values above will work against running local services from checked out [pds-service](https://github.com/tozny/pds-service) and [e3dbSearchService](https://github.com/tozny/e3dbSearchService) repos.
 
 ## Use
 

--- a/authClient/authClient.go
+++ b/authClient/authClient.go
@@ -23,6 +23,7 @@ type E3dbAuthClient struct {
     APISecret    string
     Host         string
     oauth2Helper clientcredentials.Config
+    httpClient   *http.Client
 }
 
 // GetToken attempts to retrieve and return a valid oauth2 token based on the clients
@@ -49,7 +50,10 @@ func (c *E3dbAuthClient) ValidateToken(ctx context.Context, params ValidateToken
 // AuthHTTPClient returns an http client that can be used for
 // making authenticated requests to an e3db endpoint using the provided context.
 func (c *E3dbAuthClient) AuthHTTPClient(ctx context.Context) *http.Client {
-    return c.oauth2Helper.Client(ctx)
+    if c.httpClient == nil {
+        c.httpClient = c.oauth2Helper.Client(ctx)
+    }
+    return c.httpClient
 }
 
 // New returns a new E3dbAuthClient configured with the specified apiKey and apiSecret values.

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func (err *HTTPError) Error() string {
 // MakeE3DBServiceCall attempts to call an e3db service by executing the provided request and deserializing the response into the provided result holder, returning error (if any).
 func MakeE3DBServiceCall(httpAuthorizer E3DBHTTPAuthorizer, ctx context.Context, request *http.Request, result interface{}) error {
 	client := httpAuthorizer.AuthHTTPClient(ctx)
-	return MakeRawServiceCall(client, request, result)
+	return MakeRawServiceCall(client, request.WithContext(ctx), result)
 }
 
 // MakeProxiedUserCall attempts to call an e3db service using provided user auth token to authenticate request.


### PR DESCRIPTION
- Create auth http client once and re-use across calls to allow for maximal re-use of Tozny JWT Token.