### PR TITLE
Add methods for account internal get stripe id

### DIFF
--- a/accountClient/accountClient.go
+++ b/accountClient/accountClient.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/tozny/e3db-clients-go"
-	"github.com/tozny/e3db-clients-go/authClient"
 	"net/http"
+
+	e3dbClients "github.com/tozny/e3db-clients-go"
+	"github.com/tozny/e3db-clients-go/authClient"
 )
 
 const (
@@ -73,6 +74,18 @@ func (c *E3dbAccountClient) ValidateAuthToken(ctx context.Context, params Valida
 	request, err := http.NewRequest("POST", c.Host+"/"+AccountServiceBasePath+"/auth/validate", &buf)
 	if err != nil {
 		return result, err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
+	return result, err
+}
+
+// InternalGetStripeID attempts to get account information for the specified account ID. Currently the only account information that is returned is the stripeID
+func (c *E3dbAccountClient) InternalGetAccountInfo(ctx context.Context, accountID string) (*InternalGetAccountInfoResponse, error) {
+	var result *InternalGetAccountInfoResponse
+	path := c.Host + "/internal/" + AccountServiceBasePath + "/account-info/" + accountID
+	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return result, e3dbClients.NewError(err.Error(), path, 0)
 	}
 	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
 	return result, err

--- a/accountClient/api.go
+++ b/accountClient/api.go
@@ -92,3 +92,10 @@ type RegTokenPermissions struct {
 	Enabled      bool
 	AllowedTypes []string `json:"allowed_types"`
 }
+
+// InternalGetAccountInfoResponse represents a response from calling the account service
+// internal/v1/account/account-info/{account-id} endpoint
+type InternalGetAccountInfoResponse struct {
+	StripeID       string `json:"stripe_id"`
+	SubscriptionID string `json:"stripe_subscription_id"`
+}


### PR DESCRIPTION
- Add method for new account service get stripe id internal endpoint
- Adds tests for those methods
- Refactors test file to not have duplicate code
- [Companion PR](https://github.com/tozny/account-service/pull/58)