### PR TITLE
Account Registration Endpoints

### DIFF
--- a/accountClient/api.go
+++ b/accountClient/api.go
@@ -59,9 +59,29 @@ type CreateAccountRequest struct {
 // CreateAccountResponse represents a response from making a
 // create account request to the e3db account service.
 type CreateAccountResponse struct {
-	RegistrationToken string  `json:"token"`
-	Profile           Profile `json:"profile"`
-	Account           Account `json:"account"`
+	AccountServiceToken string  `json:"token"` // JWT token for subsequent requests to the account service.
+	Profile             Profile `json:"profile"`
+	Account             Account `json:"account"`
+}
+
+type ClientRegistrationRequest struct {
+	Token  string                 `json:"token"`
+	Client ClientRegistrationInfo `json:"client"`
+}
+
+// ClientRegistrationResponse contains information about a newly-registered E3DB client
+type ClientRegistrationResponse struct {
+	ClientID     string    `json:"client_id"`
+	APIKeyID     string    `json:"api_key_id"`
+	APISecret    string    `json:"api_secret"`
+	PublicKey    ClientKey `json:"public_key"`
+	Name         string    `json:"name"`
+	RootClientID string
+}
+
+type ClientRegistrationInfo struct {
+	Name      string    `json:"name"`
+	PublicKey ClientKey `json:"public_key"`
 }
 
 // InternalGetClientAccountResponse represents a response
@@ -79,6 +99,24 @@ type ValidateTokenRequest struct {
 type ValidateTokenResponse struct {
 	AccountID string `json:"account_id"` //The account ID associated with this token
 	Valid     bool   `json:"valid"`      //Whether the token was valid
+}
+
+// CreateRegTokenRequest represents a valid request to the account service's /tokens endpoint POST.
+type CreateRegTokenRequest struct {
+	TokenPermissions
+}
+
+// CreateRegTokenResponse  represents the result of calling the account service's /tokens POST endpoint.
+type CreateRegTokenResponse struct {
+	Token       string           `json:"token"`
+	Permissions TokenPermissions `json:"permissions"`
+}
+
+// TokenPermissions permissions associated with a registration token.
+// called ClientPermissions in the account service spec
+type TokenPermissions struct {
+	Enabled bool `json:"enabled"`  // Flag a newly created client as enabled even if the default behavior is creating disabled clients
+	OneTime bool `json:"one-time"` // Automatically delete the token after it's been used to register a client
 }
 
 // RegTokenInfo is the return from the token endpoint on a valid request

--- a/accountClient/api.go
+++ b/accountClient/api.go
@@ -101,8 +101,9 @@ type ValidateTokenResponse struct {
 	Valid     bool   `json:"valid"`      //Whether the token was valid
 }
 
-// CreateRegTokenRequest represents a valid request to the account service's /tokens endpoint POST.
-type CreateRegTokenRequest struct {
+// CreateRegistrationTokenRequest represents a valid request to the account service's /tokens endpoint POST.
+type CreateRegistrationTokenRequest struct {
+	AccountServiceToken string `json:"token"` // JWT token for subsequent requests to the account service.
 	TokenPermissions
 }
 
@@ -116,7 +117,7 @@ type CreateRegTokenResponse struct {
 // called ClientPermissions in the account service spec
 type TokenPermissions struct {
 	Enabled bool `json:"enabled"`  // Flag a newly created client as enabled even if the default behavior is creating disabled clients
-	OneTime bool `json:"one-time"` // Automatically delete the token after it's been used to register a client
+	OneTime bool `json:"one_time"` // Automatically delete the token after it's been used to register a client
 }
 
 // RegTokenInfo is the return from the token endpoint on a valid request

--- a/clientServiceClient/api.go
+++ b/clientServiceClient/api.go
@@ -1,0 +1,58 @@
+package clientServiceClient
+
+import (
+	"github.com/google/uuid"
+)
+
+// AdminListRequest is the information sent to the paginated /admin GET endpooint,
+// to get the clients for a specific account (determined by authN).
+type AdminListRequest struct {
+	NextToken int64 `json:"next_token"`
+	Limit     int   `json:"limit"`
+}
+
+// AdminListResponse is a list of client information associated with a specific accountID (authN) and page.
+type AdminListResponse struct {
+	Clients   []Client `json:"clients"`
+	NextToken int64    `json:"next_token"`
+}
+
+// AdminGetResponse is the client information from the endpoint /admin/<client_id>,
+// owned by the account that authenticated this call.
+type AdminGetResponse struct {
+	Client
+}
+
+// ClientGetResponse is the client information from the endpoint /<client_id>
+type ClientGetResponse struct {
+	Client
+}
+
+// ClientRegisterRequest captures the information sent to create a client.
+type ClientRegisterRequest struct {
+	RegistrationToken string `json:"token"`
+	Client            struct {
+		Name       string            `json:"name"`
+		Type       string            `json:"type"`
+		PublicKey  map[string]string `json:"public_key"`
+		SigningKey map[string]string `json:"signing_key,omitemtpy"`
+	} `json:"client"`
+}
+
+// ClientRegisterResponse sends back the client information for a newly registered client
+type ClientRegisterResponse struct {
+	Client
+	APISecret string `json:"api_secret"`
+}
+
+// Client is all the information the user gets to see about their client.
+type Client struct {
+	ClientID    uuid.UUID         `json:"client_id"`
+	APIKeyID    string            `json:"api_key_id"`
+	Name        string            `json:"name"`
+	Type        string            `json:"type"`
+	Enabled     bool              `json:"enabled"`
+	PublicKeys  map[string]string `json:"public_key"`
+	SigningKeys map[string]string `json:"signing_key,omitemtpy"`
+	Meta        map[string]string `json:"meta,omitempty"`
+}

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -1,0 +1,78 @@
+package clientServiceClient
+
+import (
+	"context"
+	"github.com/tozny/e3db-clients-go"
+	"github.com/tozny/e3db-clients-go/authClient"
+)
+
+var (
+	ClientServiceBasePath = "v1/client/"
+)
+
+//ClientServiceClient implements an http client for communication with the client service.
+type ClientServiceClient struct {
+	APIKey    string
+	APISecret string
+	Host      string
+	*authClient.E3dbAuthClient
+}
+
+// AdminList makes authenticated call to the /admin endpoint for client service.
+func (c *ClientServiceClient) AdminList(ctx context.Context, params AdminListRequest) (*AdminListResponse, error) {
+	var result *AdminListResponse
+	path := c.Host + "/" + ClientServiceBasePath + "admin"
+	request, err := e3dbClients.CreateRequest("GET", path, params)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
+	return result, err
+}
+
+// AdminGet makes authenticated call to the /admin endpoint for client service.
+func (c *ClientServiceClient) AdminGet(ctx context.Context, clientID string) (*AdminGetResponse, error) {
+	var result *AdminGetResponse
+	path := c.Host + "/" + ClientServiceBasePath + "admin/" + clientID
+	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
+	return result, err
+}
+
+// Register registers a client.
+func (c *ClientServiceClient) Register(ctx context.Context, params ClientRegisterRequest) (*ClientRegisterResponse, error) {
+	var result *ClientRegisterResponse
+	path := c.Host + "/" + ClientServiceBasePath
+	request, err := e3dbClients.CreateRequest("POST", path, params)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
+	return result, err
+}
+
+// GetClient gets a client for clientID
+func (c *ClientServiceClient) GetClient(ctx context.Context, clientID string) (*ClientGetResponse, error) {
+	var result *ClientGetResponse
+	path := c.Host + "/" + ClientServiceBasePath + clientID
+	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
+	return result, err
+}
+
+// New returns a new E3dbSearchIndexerClient for authenticated communication with a Search Indexer service at the specified endpoint.
+func New(config e3dbClients.ClientConfig) ClientServiceClient {
+	authService := authClient.New(config)
+	return ClientServiceClient{
+		config.APIKey,
+		config.APISecret,
+		config.Host,
+		&authService,
+	}
+}


### PR DESCRIPTION
Adds registration and creation of registration tokens to the accountClient. However account service comes with its own Auth token, and it serves up extra data information in the headers of the response which we abstract out with e3db-clients-go leading to near duplicate functions. Suggestions on how to handle this welcome, focus was more on getting client-service working than making this client super clean so there might be a really simple way I've overlooked

companion PR https://github.com/tozny/client-service/pull/7