### PR TITLE
Bugfix for renamed field

### DIFF
--- a/accountClient/accountClient.go
+++ b/accountClient/accountClient.go
@@ -66,7 +66,7 @@ func (c *E3dbAccountClient) RegisterClient(ctx context.Context, params ClientReg
 }
 
 // CreateRegistrationToken makes a call to account service to create a registration token
-func (c *E3dbAccountClient) CreateRegistrationToken(ctx context.Context, params CreateRegTokenRequest) (*CreateRegTokenResponse, error) {
+func (c *E3dbAccountClient) CreateRegistrationToken(ctx context.Context, params CreateRegistrationTokenRequest) (*CreateRegTokenResponse, error) {
 	var result *CreateRegTokenResponse
 	path := c.Host + "/" + AccountServiceBasePath + "/tokens"
 	request, err := e3dbClients.CreateRequest("POST", path, params)

--- a/accountClient/api.go
+++ b/accountClient/api.go
@@ -20,7 +20,7 @@ type Account struct {
 	Company    string        `json:"company"`
 	Plan       string        `json:"plan"`
 	PublicKey  ClientKey     `json:"public_key"`
-	SigningKey EncryptionKey `json:"signing_key",omitempty`
+	SigningKey EncryptionKey `json:"signing_key,omitempty"`
 	Client     *Client       `json:"client,omitempty"`
 }
 


### PR DESCRIPTION
Bug introduced in https://github.com/tozny/e3db-clients-go/pull/34 forgot to rename an additional type after a refactor. Auto-merging because it's a small semantic, but breaking, change.