### PR TITLE
Initial batch public endpoints

### DIFF
--- a/clientServiceClient/api.go
+++ b/clientServiceClient/api.go
@@ -33,6 +33,16 @@ type ClientGetPublicResponse struct {
 	PublicClient
 }
 
+// ClientBatchPublicRequest is a list of clientIDs to get public information for.
+type ClientBatchPublicRequest struct {
+	ClientIDs []string `json:"client_ids"`
+}
+
+// ClientBatchPublicResponse is the a map of client ID to public client information from endpoint /public.
+type ClientBatchPublicResponse struct {
+	Clients map[uuid.UUID]PublicClient `json:"clients"`
+}
+
 // ClientRegisterRequest captures the information sent to create a client.
 type ClientRegisterRequest struct {
 	RegistrationToken string             `json:"token"`

--- a/clientServiceClient/api.go
+++ b/clientServiceClient/api.go
@@ -68,6 +68,11 @@ type InternalClientPatchBackupRequest struct {
 	HasBackup bool `json:"has_backup"`
 }
 
+type AdminToggleClientEnabledRequest struct {
+	ClientID string
+	Enabled  bool `json:"enabled"`
+}
+
 // Client is all the information the user gets to see about their client.
 type Client struct {
 	ClientID    uuid.UUID         `json:"client_id"`

--- a/clientServiceClient/api.go
+++ b/clientServiceClient/api.go
@@ -33,13 +33,13 @@ type ClientGetPublicResponse struct {
 	PublicClient
 }
 
-// ClientBatchPublicRequest is a list of clientIDs to get public information for.
-type ClientBatchPublicRequest struct {
+// ClientBatchPublicInfoRequest is a list of clientIDs to get public information for.
+type ClientBatchPublicInfoRequest struct {
 	ClientIDs []string `json:"client_ids"`
 }
 
-// ClientBatchPublicResponse is the a map of client ID to public client information from endpoint /public.
-type ClientBatchPublicResponse struct {
+// ClientBatchPublicInfoResponse is the a map of client ID to public client information from endpoint /public.
+type ClientBatchPublicInfoResponse struct {
 	Clients map[uuid.UUID]PublicClient `json:"clients"`
 }
 

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -78,9 +78,9 @@ func (c *ClientServiceClient) GetPublicClient(ctx context.Context, clientID stri
 	return result, err
 }
 
-// BatchPublic makes POST call to retrieve a list of clients public information for clientIDs
-func (c *ClientServiceClient) BatchPublic(ctx context.Context, params ClientBatchPublicRequest) (*ClientBatchPublicResponse, error) {
-	var result *ClientBatchPublicResponse
+// BatchPublicInfo makes POST call to retrieve a list of clients public information for clientIDs
+func (c *ClientServiceClient) BatchPublicInfo(ctx context.Context, params ClientBatchPublicInfoRequest) (*ClientBatchPublicInfoResponse, error) {
+	var result *ClientBatchPublicInfoResponse
 	path := c.Host + "/" + ClientServiceBasePath + "public"
 	request, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -78,6 +78,18 @@ func (c *ClientServiceClient) GetPublicClient(ctx context.Context, clientID stri
 	return result, err
 }
 
+// BatchPublic makes POST call to retrieve a list of clients public information for clientIDs
+func (c *ClientServiceClient) BatchPublic(ctx context.Context, params ClientBatchPublicRequest) (*ClientBatchPublicResponse, error) {
+	var result *ClientBatchPublicResponse
+	path := c.Host + "/" + ClientServiceBasePath + "public"
+	request, err := e3dbClients.CreateRequest("POST", path, params)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
+	return result, err
+}
+
 // InternalPatchBackup calls internal endpoint to flip a clients has backup flag.
 func (c *ClientServiceClient) InternalPatchBackup(ctx context.Context, params InternalClientPatchBackupRequest) error {
 	path := c.Host + "/internal/" + ClientServiceBasePath + params.ClientID + "/backup"

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -42,6 +42,17 @@ func (c *ClientServiceClient) AdminGet(ctx context.Context, clientID string) (*A
 	return result, err
 }
 
+// AdminToggleClientEnabled enables/disables clients with account auth.
+func (c *ClientServiceClient) AdminToggleClientEnabled(ctx context.Context, params AdminToggleClientEnabledRequest) error {
+	path := c.Host + "/" + ClientServiceBasePath + "admin/" + params.ClientID + "/enable"
+	request, err := e3dbClients.CreateRequest("PATCH", path, params)
+	if err != nil {
+		return err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, nil)
+	return err
+}
+
 // Register registers a client.
 func (c *ClientServiceClient) Register(ctx context.Context, params ClientRegisterRequest) (*ClientRegisterResponse, error) {
 	var result *ClientRegisterResponse


### PR DESCRIPTION
Adds client calls for the internal batchpublic endpoint to get a client's public information

Companion PR: https://github.com/tozny/client-service/pull/11
