### PR TITLE
E3db-Clients: Client Service Testing Cleanup 

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+E3DB_AUTH_SERVICE_HOST=http://platform.local.tozny.com:8003
+E3DB_API_URL=http://platform.local.tozny.com
+E3DB_ACCOUNT_SERVICE_HOST=http://platform.local.tozny.com:8002
+E3DB_STORAGE_SERVICE_HOST=http://platform.local.tozny.com:8001
+E3DB_CLIENT_SERVICE_HOST=http://platform.local.tozny.com:8003
+E3DB_HOOK_SERVICE_HOST=http://platform.local.tozny.com:10000
+E3DB_SEARCH_INDEXER_HOST=http://platform.local.tozny.com:9001
+E3DB_IDENTITY_SERVICE_HOST=http://platform.local.tozny.com:14000
+E3DB_API_KEY_ID=1d66c182779e47714cd957d4760a121580598d68e064c948e5887662c197538b
+E3DB_API_KEY_SECRET=aaadbd1cc72870e6bd41befa1273b4513d0d1fa04fb913257eec6158b6a35d75
+E3DB_CLIENT_ID=864e4b87-9eda-43fb-ae6d-d07d4275c73a
+WEBHOOK_URL=https://en8781lpip6xb.x.pipedream.net/

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ will lint and build the projects source code.
 Export valid values for use by the integration tests
 
 ```
-E3DB_API_URL=http://platform.local.tozny.com
-E3DB_AUTH_SERVICE_HOST=http://platform.local.tozny.com:8003
-E3DB_ACCOUNT_SERVICE_HOST=http://platform.local.tozny.com:8002
-E3DB_STORAGE_SERVICE_HOST=http://platform.local.tozny.com:8001
-E3DB_CLIENT_SERVICE_HOST=http://platform.local.tozny.com:8003
-E3DB_HOOK_SERVICE_HOST=http://platform.local.tozny.com:10000
-E3DB_SEARCH_INDEXER_HOST=http://platform.local.tozny.com:9001
-E3DB_IDENTITY_SERVICE_HOST=http://platform.local.tozny.com:14000
-E3DB_API_KEY_ID=1d66c182779e47714cd957d4760a121580598d68e064c948e5887662c197538b
-E3DB_API_KEY_SECRET=aaadbd1cc72870e6bd41befa1273b4513d0d1fa04fb913257eec6158b6a35d75
-E3DB_CLIENT_ID=864e4b87-9eda-43fb-ae6d-d07d4275c73a
-WEBHOOK_URL=https://en8781lpip6xb.x.pipedream.net/
+export E3DB_API_URL=http://platform.local.tozny.com
+export E3DB_AUTH_SERVICE_HOST=http://platform.local.tozny.com:8003
+export E3DB_ACCOUNT_SERVICE_HOST=http://platform.local.tozny.com:8002
+export E3DB_STORAGE_SERVICE_HOST=http://platform.local.tozny.com:8001
+export E3DB_CLIENT_SERVICE_HOST=http://platform.local.tozny.com:8003
+export E3DB_HOOK_SERVICE_HOST=http://platform.local.tozny.com:10000
+export E3DB_SEARCH_INDEXER_HOST=http://platform.local.tozny.com:9001
+export E3DB_IDENTITY_SERVICE_HOST=http://platform.local.tozny.com:14000
+export E3DB_API_KEY_ID=1d66c182779e47714cd957d4760a121580598d68e064c948e5887662c197538b
+export E3DB_API_KEY_SECRET=aaadbd1cc72870e6bd41befa1273b4513d0d1fa04fb913257eec6158b6a35d75
+export E3DB_CLIENT_ID=864e4b87-9eda-43fb-ae6d-d07d4275c73a
+export WEBHOOK_URL=https://en8781lpip6xb.x.pipedream.net/
 ```
 Then run:
 ```

--- a/README.md
+++ b/README.md
@@ -15,16 +15,18 @@ will lint and build the projects source code.
 Export valid values for use by the integration tests
 
 ```
-export E3DB_AUTH_SERVICE_HOST=http://local.e3db.com
-export E3DB_ACCOUNT_SERVICE_HOST=http://local.e3db.com
-export E3DB_STORAGE_SERVICE_HOST=http://local.e3db.com
-export E3DB_HOOK_SERVICE_HOST=http://localhost:10000
-export E3DB_SEARCH_INDEXER_HOST=http://localhost:9000
-export E3DB_API_KEY_ID=1d66c182779e47714cd957d4760a121580598d68e064c948e5887662c197538b
-export E3DB_API_KEY_SECRET=aaadbd1cc72870e6bd41befa1273b4513d0d1fa04fb913257eec6158b6a35d75
-export E3DB_CLIENT_ID=864e4b87-9eda-43fb-ae6d-d07d4275c73a
-export WEBHOOK_URL=https://en8781lpip6xb.x.pipedream.net/
-export E3DB_IDENTITY_SERVICE_HOST=http://localhost:14000
+E3DB_API_URL=http://platform.local.tozny.com
+E3DB_AUTH_SERVICE_HOST=http://platform.local.tozny.com:8003
+E3DB_ACCOUNT_SERVICE_HOST=http://platform.local.tozny.com:8002
+E3DB_STORAGE_SERVICE_HOST=http://platform.local.tozny.com:8001
+E3DB_CLIENT_SERVICE_HOST=http://platform.local.tozny.com:8003
+E3DB_HOOK_SERVICE_HOST=http://platform.local.tozny.com:10000
+E3DB_SEARCH_INDEXER_HOST=http://platform.local.tozny.com:9001
+E3DB_IDENTITY_SERVICE_HOST=http://platform.local.tozny.com:14000
+E3DB_API_KEY_ID=1d66c182779e47714cd957d4760a121580598d68e064c948e5887662c197538b
+E3DB_API_KEY_SECRET=aaadbd1cc72870e6bd41befa1273b4513d0d1fa04fb913257eec6158b6a35d75
+E3DB_CLIENT_ID=864e4b87-9eda-43fb-ae6d-d07d4275c73a
+WEBHOOK_URL=https://en8781lpip6xb.x.pipedream.net/
 ```
 Then run:
 ```

--- a/accountClient/accountClient.go
+++ b/accountClient/accountClient.go
@@ -124,26 +124,6 @@ func (c *E3dbAccountClient) InternalGetAccountInfo(ctx context.Context, accountI
 	return result, err
 }
 
-// InternalSigClientInfo attempts to get client information for the specified
-// client ID and client public singing key.
-func (c *E3dbAccountClient) InternalSigClientInfo(ctx context.Context, clientID string, sigKey string) (*InternalSigClientInfoResponse, error) {
-	// Set up the request with the proper endpoint
-	var result *InternalSigClientInfoResponse
-	path := c.Host + "/internal/" + AccountServiceBasePath + "/validate-signature-client"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
-	if err != nil {
-		return result, e3dbClients.NewError(err.Error(), path, 0)
-	}
-	// Add the user info to the request query string
-	q := request.URL.Query()
-	q.Add("user_id", clientID)
-	q.Add("public_key", sigKey)
-	request.URL.RawQuery = q.Encode()
-	// Make the service call
-	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
-	return result, err
-}
-
 // ServiceCheck checks whether the account service is up and working.
 // returning error if unable to connect service
 func (c *E3dbAccountClient) ServiceCheck(ctx context.Context) error {

--- a/accountClient/accountClient_test.go
+++ b/accountClient/accountClient_test.go
@@ -1,17 +1,14 @@
-package accountClient
+package accountClient_test
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/base64"
-	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	e3dbClients "github.com/tozny/e3db-clients-go"
-	"github.com/tozny/e3db-go/v2"
+	"github.com/tozny/e3db-clients-go/accountClient"
+	"github.com/tozny/e3db-clients-go/test"
 )
 
 var (
@@ -28,29 +25,14 @@ var (
 	}
 )
 
-func TestInternalGetClientAccountReturns404ForClientsWithNoAccount(t *testing.T) {
-	// Create internal account client
-	accounter := New(ValidClientConfig)
-	// Make request to get the account for this internal client(should be non existent)
-	ctx := context.TODO()
-	_, err := accounter.InternalGetClientAccount(ctx, e3dbClientID)
-	if err == nil {
-		t.Errorf("Expected error %s trying to get account info for client with no account %+v\n", err, accounter)
-	}
-	// Verify error is 404/not found
-	if !strings.Contains(err.Error(), "http error 404") {
-		t.Errorf("Expected 404 response, got %s", err)
-	}
-}
-
 func TestInternalGetClientAccountReturnsClientsAccountId(t *testing.T) {
 	// Create internal account client
-	accounter := New(ValidClientConfig)
+	accounter := accountClient.New(ValidClientConfig)
 	ctx := context.TODO()
-	response, err := makeNewAccount(t, ctx, accounter)
+	accountTag := uuid.New().String()
+	_, response, err := test.MakeE3DBAccount(t, &accounter, accountTag, e3dbAuthHost)
 	if err != nil {
-		t.Errorf("Failure Creating New Account\n")
-		return
+		t.Fatalf("Failure Creating New Account\n")
 	}
 	accountID := response.Profile.AccountID
 	clientID := response.Account.Client.ClientID
@@ -63,130 +45,4 @@ func TestInternalGetClientAccountReturnsClientsAccountId(t *testing.T) {
 	if account.AccountID != accountID {
 		t.Errorf("Expected account id to be %s, got %s", accountID, account.AccountID)
 	}
-}
-
-func TestInternalSigClientInfoReturnsInfo(t *testing.T) {
-	// Create internal account client
-	accounter := New(ValidClientConfig)
-	ctx := context.Background()
-	response, err := makeNewAccount(t, ctx, accounter)
-	if err != nil {
-		t.Errorf("Failure Creating New Account\n")
-		return
-	}
-	clientID := response.Account.Client.ClientID
-	sigKey := response.Account.Client.SigningKey.Ed25519
-	// Make request to lookup the client in this account
-	sigClientInfo, err := accounter.InternalSigClientInfo(ctx, clientID, sigKey)
-	if err != nil {
-		t.Errorf("Error %s trying to get account info for client %+v\n", err, accounter)
-	}
-	// Verify correct info for this client is returned
-	if sigClientInfo.Name != response.Account.Client.Name {
-		t.Errorf("Expected client name to be %q, got %q", sigClientInfo.Name, response.Account.Client.Name)
-	}
-	if sigClientInfo.ClientID.String() != clientID {
-		t.Errorf("Expected client ID to be %q, got %q", sigClientInfo.ClientID, clientID)
-	}
-	if sigClientInfo.AccountID.String() != response.Profile.AccountID {
-		t.Errorf("Expected client account ID to be %q, got %q", sigClientInfo.AccountID, response.Profile.AccountID)
-	}
-	if sigClientInfo.PublicKey != response.Account.Client.PublicKey.Curve25519 {
-		t.Errorf("Expected client public key to be %q, got %q", sigClientInfo.PublicKey, response.Account.Client.PublicKey.Curve25519)
-	}
-	if sigClientInfo.SigningKey != response.Account.Client.SigningKey.Ed25519 {
-		t.Errorf("Expected client public key to be %q, got %q", sigClientInfo.SigningKey, response.Account.Client.SigningKey.Ed25519)
-	}
-}
-
-func TestInternalGetAccountInfoForAccount(t *testing.T) {
-	// Create internal account client
-	accounter := New(ValidClientConfig)
-	// Create new account with stripe id
-	ctx := context.TODO()
-	response, err := makeNewAccount(t, ctx, accounter)
-	if err != nil {
-		t.Errorf("Failure Creating New Account\n")
-		return
-	}
-	accountID := response.Profile.AccountID
-	// Make request to lookup the account for this account's client
-	stripeResponse, err := accounter.InternalGetAccountInfo(ctx, accountID)
-	if err != nil {
-		t.Errorf("Error %s trying to get stripe id for account %+v\n", err, accounter)
-	}
-	// Verify a string that looks like a stripe id is returned
-	if !strings.HasPrefix(stripeResponse.StripeID, "cus_") {
-		t.Errorf("Expected stripe ID to look like a stripe id, but was \"%v\" <- in quotes", stripeResponse.StripeID)
-	}
-}
-
-func TestInternalGetStripeIDReturns404ForAccountsWithoutStripeID(t *testing.T) {
-	// Create internal account client
-	accounter := New(ValidClientConfig)
-	// Make request to get the account for a random accountID
-	ctx := context.TODO()
-	_, err := accounter.InternalGetAccountInfo(ctx, uuid.New().String())
-	if err == nil {
-		t.Errorf("Expected error %s trying to get account info for client with no account %+v\n", err, accounter)
-	}
-	// Verify error is 404/not found
-	if !strings.Contains(err.Error(), "http error 404") {
-		t.Errorf("Expected 404 response, got %s", err)
-	}
-}
-
-func makeNewAccount(t *testing.T, ctx context.Context, accounter E3dbAccountClient) (*CreateAccountResponse, error) {
-	const saltSize = 16
-	saltSeed := [saltSize]byte{}
-	_, err := rand.Read(saltSeed[:])
-	if err != nil {
-		t.Errorf("Failed creating salt: %s", err)
-	}
-	salt := base64.RawURLEncoding.EncodeToString(saltSeed[:])
-	publicKey, _, err := e3db.GenerateKeyPair()
-	if err != nil {
-		t.Errorf("Failed generating key pair %s", err)
-	}
-	backupPublicKey, _, err := e3db.GenerateKeyPair()
-	if err != nil {
-		t.Errorf("Failed generating key pair %s", err)
-	}
-	backupSigningKey, _, err := e3db.GenerateKeyPair()
-	if err != nil {
-		t.Errorf("Failed generating key pair %s", err)
-	}
-	accountTag := uuid.New().String()
-	createAccountParams := CreateAccountRequest{
-		Profile: Profile{
-			Name:               accountTag,
-			Email:              fmt.Sprintf("test+%s@test.com", accountTag),
-			AuthenticationSalt: salt,
-			EncodingSalt:       salt,
-			SigningKey: EncryptionKey{
-				Ed25519: publicKey,
-			},
-			PaperAuthenticationSalt: salt,
-			PaperEncodingSalt:       salt,
-			PaperSigningKey: EncryptionKey{
-				Ed25519: publicKey,
-			},
-		},
-		Account: Account{
-			Company: "ACME Testing",
-			Plan:    "free0",
-			PublicKey: ClientKey{
-				Curve25519: backupPublicKey,
-			},
-			SigningKey: EncryptionKey{
-				Ed25519: backupSigningKey,
-			},
-		},
-	}
-	// Create an account and client for that account using the specified params
-	response, err := accounter.CreateAccount(ctx, createAccountParams)
-	if err != nil {
-		t.Errorf("Error %s creating account with params %+v\n", err, createAccountParams)
-	}
-	return response, err
 }

--- a/authClient/authClient.go
+++ b/authClient/authClient.go
@@ -3,48 +3,48 @@
 package authClient
 
 import (
-    "bytes"
-    "context"
-    "encoding/json"
-    "fmt"
-    "github.com/tozny/e3db-clients-go"
-    "golang.org/x/oauth2"
-    "golang.org/x/oauth2/clientcredentials"
-    "net/http"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/tozny/e3db-clients-go"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+	"net/http"
 )
 
 const (
-    AuthServiceBasePath = "v1/auth" //HTTP PATH prefix for calls to the auth service.
+	AuthServiceBasePath = "v1/auth" //HTTP PATH prefix for calls to the auth service.
 )
 
 //E3dbAuthClient implements an http client for communication with an e3db auth service.
 type E3dbAuthClient struct {
-    APIKey       string
-    APISecret    string
-    Host         string
-    oauth2Helper clientcredentials.Config
-    httpClient   *http.Client
+	APIKey       string
+	APISecret    string
+	Host         string
+	oauth2Helper clientcredentials.Config
+	httpClient   *http.Client
 }
 
 // GetToken attempts to retrieve and return a valid oauth2 token based on the clients
 // credentials, returning token and error(if any).
 func (c *E3dbAuthClient) GetToken(ctx context.Context) (*oauth2.Token, error) {
-    return c.oauth2Helper.Token(ctx)
+	return c.oauth2Helper.Token(ctx)
 }
 
 func (c *E3dbAuthClient) ValidateToken(ctx context.Context, params ValidateTokenRequest) (*ValidateTokenResponse, error) {
-    var result *ValidateTokenResponse
-    var buf bytes.Buffer
-    err := json.NewEncoder(&buf).Encode(&params)
-    if err != nil {
-        return result, err
-    }
-    request, err := http.NewRequest("POST", c.Host+"/"+AuthServiceBasePath+"/validate", &buf)
-    if err != nil {
-        return result, err
-    }
-    internalError := e3dbClients.MakeE3DBServiceCall(c, ctx, request, &result)
-    return result, internalError
+	var result *ValidateTokenResponse
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(&params)
+	if err != nil {
+		return result, err
+	}
+	request, err := http.NewRequest("POST", c.Host+"/"+AuthServiceBasePath+"/validate", &buf)
+	if err != nil {
+		return result, err
+	}
+	internalError := e3dbClients.MakeE3DBServiceCall(c, ctx, request, &result)
+	return result, internalError
 }
 
 // AuthenticateE3DBClient validates the provided token belongs to
@@ -54,33 +54,33 @@ func (c *E3dbAuthClient) ValidateToken(ctx context.Context, params ValidateToken
 // of allowing utils-go to support AuthN without taking
 // a direct and cyclical dependency on this package
 func (c *E3dbAuthClient) AuthenticateE3DBClient(ctx context.Context, token string, internal bool) (clientID string, valid bool, err error) {
-    params := ValidateTokenRequest{
-        Token:    token,
-        Internal: internal,
-    }
-    validateTokenResponse, err := c.ValidateToken(ctx, params)
-    return validateTokenResponse.ClientId, validateTokenResponse.Valid, err
+	params := ValidateTokenRequest{
+		Token:    token,
+		Internal: internal,
+	}
+	validateTokenResponse, err := c.ValidateToken(ctx, params)
+	return validateTokenResponse.ClientId, validateTokenResponse.Valid, err
 }
 
 // AuthHTTPClient returns an http client that can be used for
 // making authenticated requests to an e3db endpoint using the provided context.
 func (c *E3dbAuthClient) AuthHTTPClient(ctx context.Context) *http.Client {
-    if c.httpClient == nil {
-        c.httpClient = c.oauth2Helper.Client(ctx)
-    }
-    return c.httpClient
+	if c.httpClient == nil {
+		c.httpClient = c.oauth2Helper.Client(ctx)
+	}
+	return c.httpClient
 }
 
 // New returns a new E3dbAuthClient configured with the specified apiKey and apiSecret values.
 func New(config e3dbClients.ClientConfig) E3dbAuthClient {
-    return E3dbAuthClient{
-        APIKey:    config.APIKey,
-        APISecret: config.APISecret,
-        Host:      config.AuthNHost,
-        oauth2Helper: clientcredentials.Config{
-            ClientID:     config.APIKey,
-            ClientSecret: config.APISecret,
-            TokenURL:     fmt.Sprintf("%s/%s/token", config.AuthNHost, AuthServiceBasePath),
-        },
-    }
+	return E3dbAuthClient{
+		APIKey:    config.APIKey,
+		APISecret: config.APISecret,
+		Host:      config.AuthNHost,
+		oauth2Helper: clientcredentials.Config{
+			ClientID:     config.APIKey,
+			ClientSecret: config.APISecret,
+			TokenURL:     fmt.Sprintf("%s/%s/token", config.AuthNHost, AuthServiceBasePath),
+		},
+	}
 }

--- a/authClient/authClient_test.go
+++ b/authClient/authClient_test.go
@@ -7,6 +7,12 @@ import (
 	"testing"
 )
 
+var (
+	e3dbAuthHost  = os.Getenv("E3DB_AUTH_SERVICE_HOST")
+	e3dbAPIKey    = os.Getenv("E3DB_API_KEY_ID")
+	e3dbAPISecret = os.Getenv("E3DB_API_KEY_SECRET")
+)
+
 func TestNewReturnsE3dbAuthClientWithSpecifiedConfiguration(t *testing.T) {
 	config := e3dbClients.ClientConfig{
 		APIKey:    "MyApiKey",
@@ -20,8 +26,6 @@ func TestNewReturnsE3dbAuthClientWithSpecifiedConfiguration(t *testing.T) {
 		t.Errorf("Expected api secret to be %s, got %+v", config.APISecret, e3dbAuth)
 	}
 }
-
-var e3dbAuthHost = os.Getenv("E3DB_AUTH_SERVICE_HOST")
 
 func TestGetTokenFailsWhenClientCredentialsAreBogus(t *testing.T) {
 	config := e3dbClients.ClientConfig{
@@ -37,9 +41,6 @@ func TestGetTokenFailsWhenClientCredentialsAreBogus(t *testing.T) {
 		t.Error("Expected error when calling GetToken with invalid auth client")
 	}
 }
-
-var e3dbAPIKey = os.Getenv("E3DB_API_KEY_ID")
-var e3dbAPISecret = os.Getenv("E3DB_API_KEY_SECRET")
 
 func TestGetTokenSucceedsWhenClientCredentialsAreValid(t *testing.T) {
 	config := e3dbClients.ClientConfig{
@@ -95,11 +96,8 @@ func TestValidateTokenReturnsValidResultsForInvalidToken(t *testing.T) {
 	e3dbAuth := New(config)
 	ctx := context.TODO()
 	validateTokenRequestParams := ValidateTokenRequest{Token: "invalidToken.AccessToken"}
-	response, err := e3dbAuth.ValidateToken(ctx, validateTokenRequestParams)
-	if err != nil {
-		t.Errorf("Error: %s calling ValidateToken", err)
-	}
-	if response.Valid != false {
-		t.Errorf("Expected token to be invalid, got %v", response)
+	_, err := e3dbAuth.ValidateToken(ctx, validateTokenRequestParams)
+	if err == nil {
+		t.Fatal("No error returned when validating invalid token")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,88 +1,98 @@
 package e3dbClients_test
 
 import (
-    "context"
-    "fmt"
-    "github.com/tozny/e3db-clients-go"
-    "github.com/tozny/e3db-clients-go/authClient"
-    "github.com/tozny/e3db-clients-go/pdsClient"
-    "github.com/tozny/e3db-go/v2"
-    "os"
-    "testing"
-    "time"
+	"context"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/tozny/e3db-clients-go"
+	"github.com/tozny/e3db-clients-go/accountClient"
+	"github.com/tozny/e3db-clients-go/authClient"
+	"github.com/tozny/e3db-clients-go/pdsClient"
+	"github.com/tozny/e3db-clients-go/test"
+	"os"
+	"testing"
 )
 
 var (
-    e3dbStorageHost      = os.Getenv("E3DB_STORAGE_SERVICE_HOST")
-    e3dbAuthHost         = os.Getenv("E3DB_AUTH_SERVICE_HOST")
-    e3dbAPIKey           = os.Getenv("E3DB_API_KEY_ID")
-    e3dbAPISecret        = os.Getenv("E3DB_API_KEY_SECRET")
-    ValidPDSClientConfig = e3dbClients.ClientConfig{
-        APIKey:    e3dbAPIKey,
-        APISecret: e3dbAPISecret,
-        Host:      e3dbStorageHost,
-        AuthNHost: e3dbAuthHost,
-    }
+	e3dbPDSHost          = os.Getenv("E3DB_STORAGE_SERVICE_HOST")
+	e3dbClientHost       = os.Getenv("E3DB_CLIENT_SERVICE_HOST")
+	e3dbAuthHost         = os.Getenv("E3DB_AUTH_SERVICE_HOST")
+	e3dbAPIKey           = os.Getenv("E3DB_API_KEY_ID")
+	e3dbAPISecret        = os.Getenv("E3DB_API_KEY_SECRET")
+	e3dbAccountHost      = os.Getenv("E3DB_ACCOUNT_SERVICE_HOST")
+	ValidPDSClientConfig = e3dbClients.ClientConfig{
+		APIKey:    e3dbAPIKey,
+		APISecret: e3dbAPISecret,
+		Host:      e3dbPDSHost,
+		AuthNHost: e3dbAuthHost,
+	}
+	ValidBootAccountClientConfig = e3dbClients.ClientConfig{
+		APIKey:    e3dbAPIKey,
+		APISecret: e3dbAPISecret,
+
+		Host:      e3dbAccountHost,
+		AuthNHost: e3dbAuthHost,
+	}
+	bootAccountClient         = accountClient.New(ValidBootAccountClientConfig)
+	validPDSRegistrationToken string
+	defaultPDSUserRecordType  = "integration_tests"
+	validPDSUser              pdsClient.E3dbPDSClient
+	validPDSUserConfig        e3dbClients.ClientConfig
+	validPDSUserID            string
 )
 
-func RegisterClient(email string) (pdsClient.E3dbPDSClient, authClient.E3dbAuthClient, string, error) {
-    var user pdsClient.E3dbPDSClient
-    var auth authClient.E3dbAuthClient
-    e3dbPDS := pdsClient.New(ValidPDSClientConfig)
-    publicKey, privateKey, err := e3db.GenerateKeyPair()
-    if err != nil {
-        return user, auth, "", err
-    }
-    params := pdsClient.RegisterClientRequest{
-        Email:      email,
-        PublicKey:  pdsClient.ClientKey{Curve25519: publicKey},
-        PrivateKey: pdsClient.ClientKey{Curve25519: privateKey},
-    }
-    ctx := context.TODO()
-    resp, err := e3dbPDS.InternalRegisterClient(ctx, params)
-    if err != nil {
-        return user, auth, "", err
-    }
-    user = pdsClient.New(e3dbClients.ClientConfig{
-        APIKey:    resp.APIKeyID,
-        APISecret: resp.APISecret,
-        Host:      e3dbStorageHost,
-        AuthNHost: e3dbAuthHost,
-    })
-    auth = authClient.New(e3dbClients.ClientConfig{
-        APIKey:    resp.APIKeyID,
-        APISecret: resp.APISecret,
-        Host:      e3dbStorageHost,
-        AuthNHost: e3dbAuthHost,
-    })
-    return user, auth, resp.ClientID, err
+//TestMain gives all tests access to a client "validPDSUser" who is authorized to write to a default record type.
+func TestMain(m *testing.M) {
+	err := setup()
+	if err != nil {
+		fmt.Printf("Could perform setup for tests due to %s", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	os.Exit(code)
 }
 
-var validPDSUser, validPDSAuthClient, validPDSUserID, _ = RegisterClient(fmt.Sprintf("test+main+%d@tozny.com", time.Now().Unix()))
+func setup() error {
+	accountTag := uuid.New().String()
+	queenAccountConfig, createAccountResp, err := test.MakeE3DBAccount(&testing.T{}, &bootAccountClient, accountTag, e3dbAuthHost)
+	if err != nil {
+		return err
+	}
+	queenAccountClient := accountClient.New(queenAccountConfig)
+	accountServiceJWT := createAccountResp.AccountServiceToken
+
+	queenAccountConfig.Host = e3dbPDSHost
+	validPDSUser = pdsClient.New(queenAccountConfig)
+	validPDSUserID = createAccountResp.Account.Client.ClientID
+	validPDSUserConfig = queenAccountConfig
+	validPDSRegistrationToken, err = test.CreateRegistrationToken(&queenAccountClient, accountServiceJWT)
+	return err
+}
 
 func TestValidateTokenReturnsValidResultsForValidExternalClientToken(t *testing.T) {
-    config := e3dbClients.ClientConfig{
-        APIKey:    e3dbAPIKey,
-        APISecret: e3dbAPISecret,
-        Host:      e3dbStorageHost,
-        AuthNHost: e3dbAuthHost,
-    }
-    e3dbAuth := authClient.New(config)
-    ctx := context.TODO()
-    userToken, err := validPDSAuthClient.GetToken(ctx)
-    if err != nil {
-        t.Errorf("Error: %v fetching token for user %v", err, validPDSAuthClient)
-    }
-    validateTokenRequestParams := authClient.ValidateTokenRequest{Token: userToken.AccessToken, Internal: true}
-    response, err := e3dbAuth.ValidateToken(ctx, validateTokenRequestParams)
-    if err != nil {
-        t.Errorf("Error: %s calling ValidateToken", err)
-    }
-    if response.Valid != true {
-        t.Errorf("Expected token to be valid, got %+v", response)
-    }
-    if response.ClientId != validPDSUserID {
-        t.Errorf("Expected token to belong to %v valid, got %+v", validPDSUserID, response)
+	bootAuthConfig := e3dbClients.ClientConfig{
+		APIKey:    e3dbAPIKey,
+		APISecret: e3dbAPISecret,
+		AuthNHost: e3dbAuthHost,
+	}
+	bootAuthClient := authClient.New(bootAuthConfig)
+	validPDSUserConfig.Host = e3dbAuthHost
+	externalClientAuthClient := authClient.New(validPDSUserConfig)
 
-    }
+	ctx := context.Background()
+	userToken, err := externalClientAuthClient.GetToken(ctx)
+	if err != nil {
+		t.Errorf("Error: %v fetching token for user %v", err, externalClientAuthClient)
+	}
+	validateTokenRequestParams := authClient.ValidateTokenRequest{Token: userToken.AccessToken, Internal: false}
+	response, err := bootAuthClient.ValidateToken(ctx, validateTokenRequestParams)
+	if err != nil {
+		t.Errorf("Error: %s calling ValidateToken", err)
+	}
+	if response.Valid != true {
+		t.Errorf("Expected token to be valid, got %+v", response)
+	}
+	if response.ClientId != validPDSUserID {
+		t.Errorf("Expected token to belong to %v valid, got %+v", validPDSUserID, response)
+	}
 }

--- a/pdsClient/pdsClient.go
+++ b/pdsClient/pdsClient.go
@@ -152,18 +152,6 @@ func (c *E3dbPDSClient) InternalAllowedReadsForAccessPolicy(ctx context.Context,
 	return result, err
 }
 
-// InternalRegisterClient uses an internal(available only to locally running e3db instances) endpoint to register a client, returning the registered client and error (if any).
-func (c *E3dbPDSClient) InternalRegisterClient(ctx context.Context, params RegisterClientRequest) (*RegisterClientResponse, error) {
-	var result *RegisterClientResponse
-	path := c.Host + "/" + PDSServiceBasePath + "/clients"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
-	if err != nil {
-		return result, err
-	}
-	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
-	return result, err
-}
-
 // InternalSearch returns records matching the provided params,
 // returning the list of records and error (if any).
 func (c *E3dbPDSClient) InternalSearch(ctx context.Context, params InternalSearchRequest) (*InternalSearchResponse, error) {

--- a/pdsClient/pdsClient_test.go
+++ b/pdsClient/pdsClient_test.go
@@ -2,15 +2,18 @@ package pdsClient
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/tozny/e3db-clients-go"
-	"github.com/tozny/e3db-clients-go/accountClient"
-	clientHelper "github.com/tozny/e3db-clients-go/test"
-	"github.com/tozny/e3db-go/v2"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/tozny/e3db-clients-go"
+	"github.com/tozny/e3db-clients-go/accountClient"
+	// clientHelper "github.com/tozny/e3db-clients-go/test"
+	"github.com/tozny/e3db-go/v2"
 )
 
 var (
@@ -653,7 +656,7 @@ func TestFindModifiedRecords(t *testing.T) {
 
 func TestAddAuthorizedAllowsAuthorizerToShareAuthorizedRecordTypes(t *testing.T) {
 	// Create authorizing account and client
-	clientConfig, authorizingAccount, err := clientHelper.MakeE3DBAccount(t, &e3dbAccountService, uuid.New().String(), e3dbAuthHost)
+	clientConfig, authorizingAccount, err := MakeE3DBAccount(t, &e3dbAccountService, uuid.New().String(), e3dbAuthHost)
 	if err != nil {
 		t.Errorf("Unable to create authorizing client using %+v", e3dbAccountService)
 	}
@@ -678,14 +681,14 @@ func TestAddAuthorizedAllowsAuthorizerToShareAuthorizedRecordTypes(t *testing.T)
 		t.Errorf("Error %s writing record to share %+v\n", err, recordToWrite)
 	}
 	// Create authorizer account and client
-	clientConfig, authorizerAccount, err := clientHelper.MakeE3DBAccount(t, &e3dbAccountService, uuid.New().String(), e3dbAuthHost)
+	clientConfig, authorizerAccount, err := MakeE3DBAccount(t, &e3dbAccountService, uuid.New().String(), e3dbAuthHost)
 	if err != nil {
 		t.Errorf("Unable to create authorizer client using %+v", e3dbAccountService)
 	}
 	authorizerClient := New(clientConfig)
 	authorizerClientID := authorizerAccount.Account.Client.ClientID
 	// Create account and client for authorizer to share records with
-	clientConfig, shareeAccount, err := clientHelper.MakeE3DBAccount(t, &e3dbAccountService, uuid.New().String(), e3dbAuthHost)
+	clientConfig, shareeAccount, err := MakeE3DBAccount(t, &e3dbAccountService, uuid.New().String(), e3dbAuthHost)
 	if err != nil {
 		t.Errorf("Unable to create authorizer client using %+v", e3dbAccountService)
 	}
@@ -866,4 +869,73 @@ func TestInternalSearchByWriterId(t *testing.T) {
 	if !found {
 		t.Errorf("expected to find record %+v\n in search results %+v\n", wroteRecord, searchResponse.Records)
 	}
+}
+
+// MakeE3DBAccount attempts to create a valid e3db account returning the root client config for the created account and error (if any).
+func MakeE3DBAccount(t *testing.T, accounter *accountClient.E3dbAccountClient, accountTag string, authNHost string) (e3dbClients.ClientConfig, *accountClient.CreateAccountResponse, error) {
+	var accountClientConfig = e3dbClients.ClientConfig{
+		Host:      accounter.Host,
+		AuthNHost: authNHost,
+	}
+	var accountResponse *accountClient.CreateAccountResponse
+	// Generate info for creating a new account
+	const saltSize = 16
+	saltSeed := [saltSize]byte{}
+	_, err := rand.Read(saltSeed[:])
+	if err != nil {
+		t.Errorf("Failed creating salt: %s", err)
+		return accountClientConfig, accountResponse, err
+	}
+	salt := base64.RawURLEncoding.EncodeToString(saltSeed[:])
+	publicKey, _, err := e3db.GenerateKeyPair()
+	if err != nil {
+		t.Errorf("Failed generating key pair %s", err)
+		return accountClientConfig, accountResponse, err
+	}
+	backupPublicKey, _, err := e3db.GenerateKeyPair()
+	if err != nil {
+		t.Errorf("Failed generating key pair %s", err)
+		return accountClientConfig, accountResponse, err
+	}
+	backupSigningKey, _, err := e3db.GenerateKeyPair()
+	if err != nil {
+		t.Errorf("Failed generating key pair %s", err)
+		return accountClientConfig, accountResponse, err
+	}
+	createAccountParams := accountClient.CreateAccountRequest{
+		Profile: accountClient.Profile{
+			Name:               accountTag,
+			Email:              fmt.Sprintf("test+%s@test.com", accountTag),
+			AuthenticationSalt: salt,
+			EncodingSalt:       salt,
+			SigningKey: accountClient.EncryptionKey{
+				Ed25519: publicKey,
+			},
+			PaperAuthenticationSalt: salt,
+			PaperEncodingSalt:       salt,
+			PaperSigningKey: accountClient.EncryptionKey{
+				Ed25519: publicKey,
+			},
+		},
+		Account: accountClient.Account{
+			Company: "ACME Testing",
+			Plan:    "free0",
+			PublicKey: accountClient.ClientKey{
+				Curve25519: backupPublicKey,
+			},
+			SigningKey: accountClient.EncryptionKey{
+				Ed25519: backupSigningKey,
+			},
+		},
+	}
+	// Create an account and client for that account using the specified params
+	ctx := context.Background()
+	accountResponse, err = accounter.CreateAccount(ctx, createAccountParams)
+	if err != nil {
+		t.Errorf("Error %s creating account with params %+v\n", err, createAccountParams)
+		return accountClientConfig, accountResponse, err
+	}
+	accountClientConfig.APIKey = accountResponse.Account.Client.APIKeyID
+	accountClientConfig.APISecret = accountResponse.Account.Client.APISecretKey
+	return accountClientConfig, accountResponse, err
 }

--- a/searchIndexerClient/indexerClient_test.go
+++ b/searchIndexerClient/indexerClient_test.go
@@ -23,7 +23,7 @@ var (
 func TestIndexRecordSucceedsWithValidInput(t *testing.T) {
 	indexer := New(ValidClientConfig)
 	params := IndexRecordRequest{RecordId: "8344742e-2789-457b-bbc8-2ce070bca6ae"}
-	ctx := context.TODO()
+	ctx := context.Background()
 	_, err := indexer.IndexRecord(ctx, params)
 	if err != nil {
 		t.Error(err)
@@ -39,7 +39,7 @@ func TestBatchIndexRecordSucceedsWithValidInput(t *testing.T) {
 			"53860b16-c37c-4bdd-95b9-39a44b536ce7",
 		},
 	}
-	ctx := context.TODO()
+	ctx := context.Background()
 	_, err := indexer.BatchIndexRecord(ctx, params)
 	if err != nil {
 		t.Error(err)

--- a/test/test.go
+++ b/test/test.go
@@ -9,6 +9,7 @@ import (
 
 	e3dbClients "github.com/tozny/e3db-clients-go"
 	"github.com/tozny/e3db-clients-go/accountClient"
+	"github.com/tozny/e3db-clients-go/clientServiceClient"
 	"github.com/tozny/e3db-go/v2"
 )
 
@@ -79,4 +80,61 @@ func MakeE3DBAccount(t *testing.T, accounter *accountClient.E3dbAccountClient, a
 	accountClientConfig.APIKey = accountResponse.Account.Client.APIKeyID
 	accountClientConfig.APISecret = accountResponse.Account.Client.APISecretKey
 	return accountClientConfig, accountResponse, err
+}
+
+// RegisterClient is a helper method to generate a client with client service,
+// returns a registration response and an empty config for said client.
+// On error t.Fatal is called halting test execution.
+func RegisterClient(t *testing.T, clientServiceHost string, registrationToken string, clientName string) (*clientServiceClient.ClientRegisterResponse, e3dbClients.ClientConfig) {
+	// init empty config to make registration requests
+	var registrationResponse *clientServiceClient.ClientRegisterResponse
+	userClientConfig := e3dbClients.ClientConfig{
+		Host: clientServiceHost,
+	}
+	publicKey, _, err := e3db.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("Failed generating public key pair %s", err)
+	}
+	signingKey, _, err := e3db.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("Failed generating signing key pair %s", err)
+	}
+	unAuthedClientServiceClient := clientServiceClient.New(userClientConfig)
+	// Register user
+	userRegister := clientServiceClient.ClientRegisterRequest{
+		RegistrationToken: registrationToken,
+		Client: clientServiceClient.ClientRegisterInfo{
+			Name:        clientName,
+			Type:        "general",
+			PublicKeys:  map[string]string{"curve25519": publicKey},
+			SigningKeys: map[string]string{"ed25519": signingKey},
+		},
+	}
+	ctx := context.Background()
+	registrationResponse, err = unAuthedClientServiceClient.Register(ctx, userRegister)
+	if err != nil {
+		t.Fatalf("unable to register user %+v, err: %s\n", userRegister, err)
+	}
+	userClientConfig.Host = ""                     // clear host, make user define
+	userClientConfig.AuthNHost = clientServiceHost // client service is now auth-service
+	userClientConfig.APIKey = registrationResponse.APIKeyID
+	userClientConfig.APISecret = registrationResponse.APISecret
+	return registrationResponse, userClientConfig
+}
+
+func CreateRegistrationToken(t *testing.T, queenAccountClient *accountClient.E3dbAccountClient, accountServiceJWT string, clientServiceHost string) string {
+	createRegParams := accountClient.CreateRegistrationTokenRequest{
+		AccountServiceToken: accountServiceJWT,
+		TokenPermissions: accountClient.TokenPermissions{
+			Enabled: true,
+			OneTime: false,
+		},
+	}
+	// create registration token
+	ctx := context.Background()
+	createdTokenResp, err := queenAccountClient.CreateRegistrationToken(ctx, createRegParams)
+	if err != nil {
+		t.Fatalf("could not create registration token %s\n", err)
+	}
+	return createdTokenResp.Token
 }

--- a/test/test.go
+++ b/test/test.go
@@ -10,6 +10,7 @@ import (
 	e3dbClients "github.com/tozny/e3db-clients-go"
 	"github.com/tozny/e3db-clients-go/accountClient"
 	"github.com/tozny/e3db-clients-go/clientServiceClient"
+	"github.com/tozny/e3db-clients-go/pdsClient"
 	"github.com/tozny/e3db-go/v2"
 )
 
@@ -137,4 +138,20 @@ func CreateRegistrationToken(t *testing.T, queenAccountClient *accountClient.E3d
 		t.Fatalf("could not create registration token %s\n", err)
 	}
 	return createdTokenResp.Token
+}
+
+func MakeClientWriterForRecordType(pdsUser pdsClient.E3dbPDSClient, clientID string, recordType string) (string, error) {
+	ctx := context.TODO()
+	putEAKParams := pdsClient.PutAccessKeyRequest{
+		WriterID:           clientID,
+		UserID:             clientID,
+		ReaderID:           clientID,
+		RecordType:         recordType,
+		EncryptedAccessKey: "SOMERANDOMNPOTENTIALLYNONVALIDKEY",
+	}
+	resp, err := pdsUser.PutAccessKey(ctx, putEAKParams)
+	if err != nil {
+		return "", err
+	}
+	return resp.EncryptedAccessKey, err
 }

--- a/test/test.go
+++ b/test/test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tozny/e3db-clients-go/accountClient"
 	"github.com/tozny/e3db-clients-go/clientServiceClient"
 	"github.com/tozny/e3db-clients-go/pdsClient"
+
 	"github.com/tozny/e3db-go/v2"
 )
 

--- a/test/test.go
+++ b/test/test.go
@@ -123,6 +123,20 @@ func RegisterClient(clientServiceHost string, registrationToken string, clientNa
 	return registrationResponse, userClientConfig, err
 }
 
+func CreatePDSClient(pdsHost string, clientHost string, registrationToken string, clientName string, recordType string) (pdsClient.E3dbPDSClient, string, e3dbClients.ClientConfig, error) {
+	var userClientID string
+	var userPDSClient pdsClient.E3dbPDSClient
+	registrationResponse, userClientConfig, err := RegisterClient(clientHost, registrationToken, clientName)
+	if err != nil {
+		return userPDSClient, userClientID, userClientConfig, err
+	}
+	userClientConfig.Host = pdsHost
+	userPDSClient = pdsClient.New(userClientConfig)
+	userClientID = registrationResponse.ClientID.String()
+	_, err = MakeClientWriterForRecordType(userPDSClient, userClientID, recordType)
+	return userPDSClient, userClientID, userClientConfig, err
+}
+
 // CreateRegistrationToken makes a registration token for a queenAccount
 // requires the accountServiceJWT recieved from successfully completing an account-service challenge.
 func CreateRegistrationToken(queenAccountClient *accountClient.E3dbAccountClient, accountServiceJWT string) (string, error) {

--- a/test/test.go
+++ b/test/test.go
@@ -155,3 +155,18 @@ func MakeClientWriterForRecordType(pdsUser pdsClient.E3dbPDSClient, clientID str
 	}
 	return resp.EncryptedAccessKey, err
 }
+
+func WriteRandomRecordForUser(user pdsClient.E3dbPDSClient, recordType string, writerID string) (*pdsClient.Record, error) {
+	ctx := context.TODO()
+	data := map[string]string{"data": "unencrypted"}
+	recordToWrite := pdsClient.WriteRecordRequest{
+		Data: data,
+		Metadata: pdsClient.Meta{
+			Type:     recordType,
+			WriterID: writerID,
+			UserID:   writerID,
+			Plain:    map[string]string{"key": "value"},
+		},
+	}
+	return user.WriteRecord(ctx, recordToWrite)
+}

--- a/test/test.go
+++ b/test/test.go
@@ -156,16 +156,19 @@ func MakeClientWriterForRecordType(pdsUser pdsClient.E3dbPDSClient, clientID str
 	return resp.EncryptedAccessKey, err
 }
 
-func WriteRandomRecordForUser(user pdsClient.E3dbPDSClient, recordType string, writerID string) (*pdsClient.Record, error) {
+func WriteRandomRecordForUser(user pdsClient.E3dbPDSClient, recordType string, writerID string, meta *map[string]string) (*pdsClient.Record, error) {
 	ctx := context.TODO()
 	data := map[string]string{"data": "unencrypted"}
+	if meta == nil {
+		meta = &map[string]string{"key": "value"}
+	}
 	recordToWrite := pdsClient.WriteRecordRequest{
 		Data: data,
 		Metadata: pdsClient.Meta{
 			Type:     recordType,
 			WriterID: writerID,
 			UserID:   writerID,
-			Plain:    map[string]string{"key": "value"},
+			Plain:    *meta,
 		},
 	}
 	return user.WriteRecord(ctx, recordToWrite)


### PR DESCRIPTION
This PR was initially meant to pull out and consolidate shared testing helper code from other repos, but I found that the testing methods within this repo also use the bad register endpoint. 

This PR:
- Removes bad testing methods
- Removes non-existent endpoints
- Consolidates shared test helper methods