### PR TITLE
Add type safety to keys and crypto methods to support tozstore-like operations

### DIFF
--- a/clientServiceClient/api.go
+++ b/clientServiceClient/api.go
@@ -2,7 +2,6 @@ package clientServiceClient
 
 import (
 	"github.com/google/uuid"
-	e3dbClients "github.com/tozny/e3db-clients-go"
 )
 
 // AdminListRequest is the information sent to the paginated /admin GET endpooint,
@@ -72,17 +71,6 @@ type ClientInfoForSignatureRequest struct {
 type ClientInfoForTokenClaimsRequest struct {
 	ClientID string `json:"client_id"`
 }
-
-// type AuthNClientInfoResponse struct {
-// 	ClientID   uuid.UUID         `json:"client_id"`
-// 	AccountID  uuid.UUID         `json:"account_id"`
-// 	Name       string            `json:"name"`
-// 	PublicKey  map[string]string `json:"public_key"`
-// 	SigningKey map[string]string `json:"signing_key,omitemtpy"`
-// 	Type       string            `json:"type"`
-// }
-
-type AuthNClientInfoResponse = e3dbClients.ToznyAuthenticatedContext
 
 type InternalClientPatchBackupRequest struct {
 	ClientID  string

--- a/clientServiceClient/api.go
+++ b/clientServiceClient/api.go
@@ -2,6 +2,7 @@ package clientServiceClient
 
 import (
 	"github.com/google/uuid"
+	e3dbClients "github.com/tozny/e3db-clients-go"
 )
 
 // AdminListRequest is the information sent to the paginated /admin GET endpooint,
@@ -72,14 +73,16 @@ type ClientInfoForTokenClaimsRequest struct {
 	ClientID string `json:"client_id"`
 }
 
-type AuthNClientInfoResponse struct {
-	ClientID   uuid.UUID         `json:"client_id"`
-	AccountID  uuid.UUID         `json:"account_id"`
-	Name       string            `json:"name"`
-	PublicKey  map[string]string `json:"public_key"`
-	SigningKey map[string]string `json:"signing_key,omitemtpy"`
-	Type       string            `json:"type"`
-}
+// type AuthNClientInfoResponse struct {
+// 	ClientID   uuid.UUID         `json:"client_id"`
+// 	AccountID  uuid.UUID         `json:"account_id"`
+// 	Name       string            `json:"name"`
+// 	PublicKey  map[string]string `json:"public_key"`
+// 	SigningKey map[string]string `json:"signing_key,omitemtpy"`
+// 	Type       string            `json:"type"`
+// }
+
+type AuthNClientInfoResponse = e3dbClients.ToznyAuthenticatedContext
 
 type InternalClientPatchBackupRequest struct {
 	ClientID  string

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -118,8 +118,8 @@ func (c *ClientServiceClient) InternalPatchBackup(ctx context.Context, params In
 }
 
 // InternalClientInfoForSignature calls internal endpoint to authenticate for clientID and publicKey.
-func (c *ClientServiceClient) InternalClientInfoForSignature(ctx context.Context, params ClientInfoForSignatureRequest) (*AuthNClientInfoResponse, error) {
-	var result *AuthNClientInfoResponse
+func (c *ClientServiceClient) InternalClientInfoForSignature(ctx context.Context, params ClientInfoForSignatureRequest) (*e3dbClients.ToznyAuthenticatedClientContext, error) {
+	var result *e3dbClients.ToznyAuthenticatedClientContext
 	path := c.Host + "/internal/" + ClientServiceBasePath + params.ClientID + "/signature-context"
 	request, err := e3dbClients.CreateRequest("GET", path, params)
 	if err != nil {
@@ -134,8 +134,8 @@ func (c *ClientServiceClient) InternalClientInfoForSignature(ctx context.Context
 }
 
 // InternalClientInfoForTokenClaims calls internal endpoint to authenticate for a clientID.
-func (c *ClientServiceClient) InternalClientInfoForTokenClaims(ctx context.Context, params ClientInfoForTokenClaimsRequest) (*AuthNClientInfoResponse, error) {
-	var result *AuthNClientInfoResponse
+func (c *ClientServiceClient) InternalClientInfoForTokenClaims(ctx context.Context, params ClientInfoForTokenClaimsRequest) (*e3dbClients.ToznyAuthenticatedClientContext, error) {
+	var result *e3dbClients.ToznyAuthenticatedClientContext
 	path := c.Host + "/internal/" + ClientServiceBasePath + params.ClientID + "/token-context"
 	request, err := e3dbClients.CreateRequest("GET", path, params)
 	if err != nil {

--- a/crypto.go
+++ b/crypto.go
@@ -54,10 +54,10 @@ type EncryptionKeys AsymmetricKeypair
 // or externally (client calls).
 type PublicEncryptionKeys Keys
 
-// PublicSignatureKeys are a set of key, NIST or Sodium, used within Tozny to sign requests
+// PublicSigningKeys are a set of key, NIST or Sodium, used within Tozny to sign requests
 // It's the responsibility of the user to assign proper key types to raw keys obtained internally (db)
 // or externally (client calls).
-type PublicSignatureKeys Keys
+type PublicSigningKeys Keys
 
 // GenerateSigningKeys generates a `base64.RawURLEncoding` private and public key
 // for signing requests and data on behalf of Tozny clients,

--- a/crypto.go
+++ b/crypto.go
@@ -14,9 +14,9 @@ const (
 	DefaultSigningKeyType    = "ed25519"
 )
 
-// ToznyAuthenticatedContext represents the contextual information provided by cyclops to downstream services
+// ToznyAuthenticatedClientContext represents the contextual information provided by cyclops to downstream services
 // when a user is successfully authenticated.
-type ToznyAuthenticatedContext struct {
+type ToznyAuthenticatedClientContext struct {
 	ClientID       uuid.UUID            `json:"client_id"`
 	AccountID      uuid.UUID            `json:"account_id"`
 	Name           string               `json:"name"`

--- a/crypto.go
+++ b/crypto.go
@@ -105,13 +105,13 @@ func EncryptAccessKey(rawAK SymmetricKey, encryptionKeys EncryptionKeys) (string
 
 // RandomSymmetricKey generates a random symmetric key (secret).
 func RandomSymmetricKey() SymmetricKey {
-	key := &[SymmetricKeySize]byte{}
+	key := [SymmetricKeySize]byte{}
 	_, err := rand.Read(key[:])
 	if err != nil {
 		// we don't expect this to fail
 		panic("random number generation failed")
 	}
-	return key
+	return &key
 }
 
 // RandomNonce generates a random nonce of size NoneSize
@@ -125,7 +125,7 @@ func RandomNonce() Nonce {
 	return &b
 }
 
-// BoxEncryptToBase64 uses asymmetric encryption key sot encrypt data
+// BoxEncryptToBase64 uses asymmetric encryption keys to encrypt data
 func BoxEncryptToBase64(data []byte, encryptionKeys EncryptionKeys) (string, string, error) {
 	n := RandomNonce()
 	rawPubKey, err := Base64Decode(encryptionKeys.Public.Material)

--- a/crypto.go
+++ b/crypto.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/tozny/e3db-go/v2"
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/crypto/nacl/secretbox"
@@ -27,17 +26,6 @@ type SymmetricKey *[SymmetricKeySize]byte
 
 // Nonce is a type that represents nonce randomly generated unique value that is used once in encrypting data.
 type Nonce *[NonceSize]byte
-
-// ToznyAuthenticatedClientContext represents the contextual information provided by cyclops to downstream services
-// when a user is successfully authenticated.
-type ToznyAuthenticatedClientContext struct {
-	ClientID       uuid.UUID            `json:"client_id"`
-	AccountID      uuid.UUID            `json:"account_id"`
-	Name           string               `json:"name"`
-	EncryptionKeys PublicEncryptionKeys `json:"encryption_keys"`        // Tozny does not know a user's private encryption key
-	SignatureKeys  PublicSignatureKeys  `json:"signing_keys,omitempty"` // Tozny does not know a user's private signing key
-	ClientType     string               `json:"type"`
-}
 
 // Key wraps material generated using an algorithm/curve for use in cryptographic operations
 type Key struct {

--- a/crypto.go
+++ b/crypto.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 
+	"github.com/google/uuid"
 	sodium "golang.org/x/crypto/nacl/sign"
 )
 
@@ -13,11 +14,25 @@ const (
 	DefaultSigningKeyType    = "ed25519"
 )
 
+// ToznyAuthenticatedContext represents the contextual information provided by cyclops to downstream services
+// when a user is successfully authenticated.
+type ToznyAuthenticatedContext struct {
+	ClientID       uuid.UUID            `json:"client_id"`
+	AccountID      uuid.UUID            `json:"account_id"`
+	Name           string               `json:"name"`
+	EncryptionKeys PublicEncryptionKeys `json:"encryption_keys"`        // Tozny does not know a user's private encryption key
+	SignatureKeys  PublicSignatureKeys  `json:"signing_keys,omitempty"` // Tozny does not know a user's private signing key
+	ClientType     string               `json:"type"`
+}
+
 // Key wraps material generated using an algorithm/curve for use in cryptographic operations
 type Key struct {
 	Material string
 	Type     string // e.g. Curve25519
 }
+
+// Keys is a map of key type to key material
+type Keys map[string]string
 
 // AsymmetricKeypair wraps a public and private key used for
 // asymmetric cryptographic operations.
@@ -31,6 +46,16 @@ type SigningKeys AsymmetricKeypair
 
 // EncryptionKeys wraps a keypair for encrypting and decrypting data
 type EncryptionKeys AsymmetricKeypair
+
+// PublicEncryptionKeys are a set of keys, NIST or Sodium, used within TozStore to encrypt stored data.
+// It's the responsibility of the user to assign proper key types to raw keys obtained internally (db)
+// or externally (client calls).
+type PublicEncryptionKeys Keys
+
+// PublicSignatureKeys are a set of key, NIST or Sodium, used within Tozny to sign requests
+// It's the responsibility of the user to assign proper key types to raw keys obtained internally (db)
+// or externally (client calls).
+type PublicSignatureKeys Keys
 
 // GenerateSigningKeys generates a `base64.RawURLEncoding` private and public key
 // for signing requests and data on behalf of Tozny clients,

--- a/crypto.go
+++ b/crypto.go
@@ -3,8 +3,13 @@ package e3dbClients
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/tozny/e3db-go/v2"
+	"golang.org/x/crypto/nacl/box"
+	"golang.org/x/crypto/nacl/secretbox"
 	sodium "golang.org/x/crypto/nacl/sign"
 )
 
@@ -12,7 +17,16 @@ const (
 	// https://security.stackexchange.com/questions/50878/ecdsa-vs-ecdh-vs-ed25519-vs-curve25519
 	DefaultEncryptionKeyType = "curve25519"
 	DefaultSigningKeyType    = "ed25519"
+	SymmetricKeySize         = 32
+	NonceSize                = 24
 )
+
+// SymmetricKey is used for fast encryption of larger amounts of data
+// also referred to as the 'SecretKey'
+type SymmetricKey *[SymmetricKeySize]byte
+
+// Nonce is a type that represents nonce randomly generated unique value that is used once in encrypting data.
+type Nonce *[NonceSize]byte
 
 // ToznyAuthenticatedClientContext represents the contextual information provided by cyclops to downstream services
 // when a user is successfully authenticated.
@@ -77,4 +91,122 @@ func GenerateSigningKeys() (SigningKeys, error) {
 			Type:     DefaultSigningKeyType},
 	}
 	return signingKeys, err
+}
+
+// EncryptData accepts a record object of plain meta and plain data, returning
+// a record with data keys encrypted with dk and ak according to Tozstore spec.
+func EncryptData(Data map[string]string, ak SymmetricKey) *map[string]string {
+	encryptedData := make(map[string]string)
+	for k, v := range Data {
+		dk := RandomSymmetricKey()
+		ef, efN := SecretBoxEncryptToBase64([]byte(v), dk)
+		edk, edkN := SecretBoxEncryptToBase64(dk[:], ak)
+		encryptedData[k] = fmt.Sprintf("%s.%s.%s.%s", edk, edkN, ef, efN)
+	}
+	return &encryptedData
+}
+
+// EncryptAccessKey returns encrypted access key with nonce attached.
+func EncryptAccessKey(rawAK SymmetricKey, encryptionKeys EncryptionKeys) (string, error) {
+	eak, eakN, err := BoxEncryptToBase64(rawAK[:], encryptionKeys)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s.%s", eak, eakN), err
+}
+
+// RandomSymmetricKey generates a random symmetric key (secret).
+func RandomSymmetricKey() SymmetricKey {
+	key := &[SymmetricKeySize]byte{}
+	_, err := rand.Read(key[:])
+	if err != nil {
+		// we don't expect this to fail
+		panic("random number generation failed")
+	}
+	return key
+}
+
+// RandomNonce generates a random nonce of size NoneSize
+func RandomNonce() Nonce {
+	b := [NonceSize]byte{}
+	_, err := rand.Read(b[:])
+	if err != nil {
+		// we don't expect this to fail
+		panic("random number generation failed")
+	}
+	return &b
+}
+
+// BoxEncryptToBase64 uses asymmetric encryption key sot encrypt data
+func BoxEncryptToBase64(data []byte, encryptionKeys EncryptionKeys) (string, string, error) {
+	n := RandomNonce()
+	rawPubKey, err := Base64Decode(encryptionKeys.Public.Material)
+	if err != nil {
+		return "", "", err
+	}
+	rawPrivKey, err := Base64Decode(encryptionKeys.Private.Material)
+	if err != nil {
+		return "", "", err
+	}
+	pubKey := e3db.MakePublicKey(rawPubKey)
+	privKey := e3db.MakePrivateKey(rawPrivKey)
+	ciphertext := box.Seal(nil, data, n, pubKey, privKey)
+	return Base64Encode(ciphertext), Base64Encode(n[:]), err
+}
+
+// SecretBoxEncryptToBase64 uses an NaCl secret_box to encrypt a byte
+// slice with the given secret key and a random nonce,
+// returning the Base64URL encoded ciphertext and nonce.
+func SecretBoxEncryptToBase64(data []byte, key SymmetricKey) (string, string) {
+	n := RandomNonce()
+	box := secretbox.Seal(nil, data, n, key)
+	return Base64Encode(box), Base64Encode(n[:])
+}
+
+// SecretBoxDecryptFromBase64 uses NaCl secret_box to decrypt a
+// string containing ciphertext along with the associated
+// nonce, both Base64URL encoded. Returns the ciphertext bytes,
+// or an error if the authentication check fails when decrypting.
+func SecretBoxDecryptFromBase64(ciphertext, nonce string, key SymmetricKey) ([]byte, error) {
+	ciphertextBytes, err := Base64Decode(ciphertext)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceBytes, err := Base64Decode(nonce)
+	if err != nil {
+		return nil, err
+	}
+
+	n := MakeNonce(nonceBytes)
+	plaintext, ok := secretbox.Open(nil, ciphertextBytes, n, key)
+	if !ok {
+		return nil, errors.New("decryption failed")
+	}
+
+	return plaintext, nil
+}
+
+// MakeSymmetricKey loads an existing secret key from a byte array.
+func MakeSymmetricKey(b []byte) SymmetricKey {
+	key := [SymmetricKeySize]byte{}
+	copy(key[:], b)
+	return &key
+}
+
+// MakeNonce loads an existing nonce from a byte array.
+func MakeNonce(b []byte) Nonce {
+	n := [NonceSize]byte{}
+	copy(n[:], b)
+	return &n
+}
+
+// Base64Encode wrapper to base64 encode data.
+func Base64Encode(data []byte) string {
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+// Base64Decode wrapper to base64 decode data.
+func Base64Decode(s string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(s)
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // ClientConfig wraps configuration
@@ -21,6 +23,17 @@ type ClientConfig struct {
 	AuthNHost      string
 	SigningKeys    SigningKeys    // AsymmetricEncryptionKeypair used for signing and authenticating requests
 	EncryptionKeys EncryptionKeys // AsymmetricEncryptionKeypair used for encrypting and decrypting data
+}
+
+// ToznyAuthenticatedClientContext represents the contextual information provided by cyclops to downstream services
+// when a user is successfully authenticated.
+type ToznyAuthenticatedClientContext struct {
+	ClientID       uuid.UUID            `json:"client_id"`
+	AccountID      uuid.UUID            `json:"account_id"`
+	Name           string               `json:"name"`
+	EncryptionKeys PublicEncryptionKeys `json:"encryption_keys"`        // Tozny does not know a user's private encryption key
+	SignatureKeys  PublicSignatureKeys  `json:"signing_keys,omitempty"` // Tozny does not know a user's private signing key
+	Type           string               `json:"type"`
 }
 
 // E3DBHTTPAuthorizer implements the functionality needed to make

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ type ToznyAuthenticatedClientContext struct {
 	AccountID      uuid.UUID            `json:"account_id"`
 	Name           string               `json:"name"`
 	EncryptionKeys PublicEncryptionKeys `json:"encryption_keys"`        // Tozny does not know a user's private encryption key
-	SignatureKeys  PublicSignatureKeys  `json:"signing_keys,omitempty"` // Tozny does not know a user's private signing key
+	SigningKeys    PublicSigningKeys    `json:"signing_keys,omitempty"` // Tozny does not know a user's private signing key
 	Type           string               `json:"type"`
 }
 

--- a/storageClient/api.go
+++ b/storageClient/api.go
@@ -1,0 +1,27 @@
+package storageClient
+
+import (
+	"time"
+)
+
+// Note is the API-level note object that mirrors the note JSON objects.
+type Note struct {
+	NoteID              string            `json:"note_id,omitempty"`
+	IDString            string            `json:"id_string"`
+	ClientID            string            `json:"client_id,omitempty"`
+	Mode                string            `json:"mode"`
+	RecipientSigningKey string            `json:"recipient_signing_key"`
+	WriterSigningKey    string            `json:"writer_signing_key"`
+	WriterEncryptionKey string            `json:"writer_encryption_key"`
+	EncryptedAccessKey  string            `json:"encrypted_access_key"`
+	Type                string            `json:"type"`
+	Data                map[string]string `json:"data"`
+	Plain               map[string]string `json:"plain"`
+	FileMeta            map[string]string `json:"file_meta,omitempty"`
+	Signature           string            `json:"signature"`
+	CreatedAt           time.Time         `json:"created_at"`
+	MaxViews            int               `json:"max_views,omitempty"`
+	Views               int               `json:"views"`
+	Expiration          time.Time         `json:"expiration,omitempty"`
+	Expires             bool              `json:"expires,omitempty"`
+}

--- a/storageClient/storageClient.go
+++ b/storageClient/storageClient.go
@@ -1,0 +1,55 @@
+package storageClient
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/tozny/e3db-clients-go"
+)
+
+const (
+	storageServiceBasePath = "/v2/storage"
+)
+
+//StorageClient implements an http client for communication with the metrics service.
+type StorageClient struct {
+	ClientID    string
+	SigningKeys e3dbClients.SigningKeys
+	Host        string // host will generally need to be cyclops service to get the X-Tozny-Auth header
+	httpClient  *http.Client
+}
+
+func (c *StorageClient) WriteNote(ctx context.Context, params Note) (*Note, error) {
+	var result *Note
+	path := c.Host + storageServiceBasePath + "/notes"
+	request, err := e3dbClients.CreateRequest("POST", path, params)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	return result, err
+}
+
+func (c *StorageClient) ReadNote(ctx context.Context, noteID string) (*Note, error) {
+	var result *Note
+	path := c.Host + storageServiceBasePath + "/notes"
+	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return result, err
+	}
+	urlParams := request.URL.Query()
+	urlParams.Set("note_id", noteID)
+	request.URL.RawQuery = urlParams.Encode()
+	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	return result, err
+}
+
+// New returns a new E3dbSearchIndexerClient for authenticated communication with a Search Indexer service at the specified endpoint.
+func New(config e3dbClients.ClientConfig) StorageClient {
+	return StorageClient{
+		Host:        config.Host,
+		SigningKeys: config.SigningKeys,
+		ClientID:    config.ClientID,
+		httpClient:  &http.Client{},
+	}
+}

--- a/storageClient/storageClient_test.go
+++ b/storageClient/storageClient_test.go
@@ -1,0 +1,83 @@
+package storageClient
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	e3dbClients "github.com/tozny/e3db-clients-go"
+	"github.com/tozny/e3db-clients-go/accountClient"
+	"github.com/tozny/e3db-clients-go/test"
+)
+
+var (
+	cyclopsServiceHost = os.Getenv("TOZNY_CYCLOPS_SERVICE_HOST")
+)
+
+func TestFullSignatureAuthenticationFlowSucceedsNoUID(t *testing.T) {
+	ctx := context.Background()
+	// Make request through cyclops to test tozny header is parsed properly
+	registrationClient := accountClient.New(e3dbClients.ClientConfig{Host: cyclopsServiceHost}) // empty account host to make registration request
+	queenClientConfig, _, err := test.MakeE3DBAccount(t, &registrationClient, uuid.New().String(), cyclopsServiceHost)
+	if err != nil {
+		t.Fatalf("Could not register account %s\n", err)
+	}
+	queenClientConfig.Host = cyclopsServiceHost
+	queenClientConfig.ClientID = "" // remove clientID
+	storageServiceClient := New(queenClientConfig)
+	noteToWrite, err := generateNote(queenClientConfig.SigningKeys.Public.Material, queenClientConfig)
+	if err != nil {
+		t.Fatalf("unable to generate note with config %+v\n", queenClientConfig)
+	}
+	_, err = storageServiceClient.WriteNote(ctx, *noteToWrite)
+	if err != nil {
+		t.Errorf("unable to write note %+v, to storage servive %s\n", noteToWrite, err)
+	}
+}
+
+func TestFullSignatureAuthenticationFlowSucceedsWithUID(t *testing.T) {
+	ctx := context.Background()
+	// Make request through cyclops to test tozny header is parsed properly
+	registrationClient := accountClient.New(e3dbClients.ClientConfig{Host: cyclopsServiceHost}) // empty account host to make registration request
+	queenClientConfig, _, err := test.MakeE3DBAccount(t, &registrationClient, uuid.New().String(), cyclopsServiceHost)
+	if err != nil {
+		t.Fatalf("Could not register account %s\n", err)
+	}
+	StorageClient := New(queenClientConfig)
+	noteToWrite, err := generateNote(queenClientConfig.SigningKeys.Public.Material, queenClientConfig)
+	if err != nil {
+		t.Fatalf("unable to generate note with config %+v\n", queenClientConfig)
+	}
+	_, err = StorageClient.WriteNote(ctx, *noteToWrite)
+	if err != nil {
+		t.Errorf("unable to write note %+v, to storage servive %s\n", noteToWrite, err)
+	}
+}
+
+func generateNote(recipientSigningKey string, clientConfig e3dbClients.ClientConfig) (*Note, error) {
+	rawData := map[string]string{
+		"key1": "rawnote",
+		"key2": "unprocessednote",
+		"key3": "organicnote",
+	}
+	ak := e3dbClients.RandomSymmetricKey()
+	eak, err := e3dbClients.EncryptAccessKey(ak, clientConfig.EncryptionKeys)
+	if err != nil {
+		return nil, err
+	}
+	encryptedData := e3dbClients.EncryptData(rawData, ak)
+
+	return &Note{
+		Mode:                "Sodium",
+		RecipientSigningKey: recipientSigningKey,
+		WriterSigningKey:    clientConfig.SigningKeys.Public.Material,
+		WriterEncryptionKey: clientConfig.EncryptionKeys.Public.Material,
+		EncryptedAccessKey:  eak,
+		Type:                "Integration Test",
+		Data:                *encryptedData,
+		Plain:               map[string]string{"extra1": "not encrypted", "extra2": "more plain data"},
+		Signature:           "signed",
+		MaxViews:            5,
+	}, err
+}

--- a/storageClient/storageTest.go
+++ b/storageClient/storageTest.go
@@ -1,0 +1,1 @@
+package storageClient

--- a/storageClient/storageTest.go
+++ b/storageClient/storageTest.go
@@ -1,1 +1,0 @@
-package storageClient


### PR DESCRIPTION
Defines some shared types used across services like the additional tozny client contextual information and public encryption keys.

Ports over crypto methods from our SDK so we can use proper encryption in Integration tests

Adds storage client to for use in integration tests against storagev2/notes service.