### PR TITLE
Upsert note call for storage client

### DIFF
--- a/storageClient/storageClient.go
+++ b/storageClient/storageClient.go
@@ -30,6 +30,17 @@ func (c *StorageClient) WriteNote(ctx context.Context, params Note) (*Note, erro
 	return result, err
 }
 
+func (c *StorageClient) UpsertNoteByIDString(ctx context.Context, params Note) (*Note, error) {
+	var result *Note
+	path := c.Host + storageServiceBasePath + "/notes"
+	request, err := e3dbClients.CreateRequest("PUT", path, params)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	return result, err
+}
+
 func (c *StorageClient) ReadNote(ctx context.Context, noteID string) (*Note, error) {
 	var result *Note
 	path := c.Host + storageServiceBasePath + "/notes"


### PR DESCRIPTION
Adds call to storage/notes client for a PUT request on /notes. This endpoint allows you to upsert a note based on IDString conflicts. It will be used to change a identity client's password.