### PR TITLE
Add storageClient API definitions for TozID EACP 

### DIFF
--- a/identityClient/api.go
+++ b/identityClient/api.go
@@ -112,7 +112,7 @@ type BrokerChallengeRequest struct {
 
 // EmailOTP wraps a one time password provided via an email challenge.
 type EmailOTP struct {
-	EmailOTP string `json:email_otp` // The one-time password from the email challenge issued.
+	EmailOTP string `json:"email_otp"` // The one-time password from the email challenge issued.
 }
 
 // BrokerLoginRequest proof that the Identity has completed the broker challenge

--- a/identityClient/api.go
+++ b/identityClient/api.go
@@ -135,3 +135,25 @@ type BrokerLoginResponse struct {
 type InternalUpdateActiveForKeycloakUserID struct {
 	Active bool `json:"active"`
 }
+
+// RealmOIDCPublicKey wraps parameters for a public key in JWK form used for OIDC flows for a given realm.
+// JWK spec https://tools.ietf.org/html/rfc7517
+// RSA key parameters https://www.gnupg.org/documentation/manuals/gcrypt-devel/RSA-key-parameters.html
+type RealmOIDCPublicKey struct {
+	KeyID string `json:"kid"`
+	// Identifies the algorithm intended for use with the key.
+	Algorithim string `json:"alg"`
+	// The cryptographic algorithm family used with the key, such as "RSA" or "EC".
+	KeyType string `json:"kty"`
+	// RSA Public key exponent
+	RSAExponent string `json:"e"`
+	// RSA public modulus n.
+	RSAModulus string `json:"n"`
+	// The intended use of the public key, one of `sig`(nature) or `enc`(oding)
+	Use string `json:"use"`
+}
+
+// ListRealmOIDCKeysResponse wraps a list of keys used for OIDC flows for a given realm.
+type ListRealmOIDCKeysResponse struct {
+	Keys []RealmOIDCPublicKey `json:"keys"`
+}

--- a/identityClient/identityClient.go
+++ b/identityClient/identityClient.go
@@ -30,6 +30,21 @@ type E3dbIdentityClient struct {
 	httpClient  *http.Client
 }
 
+// ListOIDCKeysForRealm returns a list of all configured keys for OIDC flows for a given realm and error (if any)
+func (c *E3dbIdentityClient) ListOIDCKeysForRealm(ctx context.Context, realmName string) (ListRealmOIDCKeysResponse, error) {
+	var listedKeys ListRealmOIDCKeysResponse
+	path := fmt.Sprintf("%s%s/%s/protocol/openid-connect/certs", c.Host, realmLoginPathPrefix, realmName)
+	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return listedKeys, err
+	}
+	err = e3dbClients.MakeRawServiceCall(c.httpClient, request, &listedKeys)
+	if err != nil {
+		return listedKeys, err
+	}
+	return listedKeys, err
+}
+
 // BrokerIdentityChallange begins a broker-based login flow using the specified params, returning error (if any).
 func (c *E3dbIdentityClient) BrokerIdentityChallenge(ctx context.Context, params BrokerChallengeRequest) error {
 	path := c.Host + identityServiceBasePath + fmt.Sprintf("/broker/%s/%s/challenge", realmResourceName, params.RealmName)

--- a/storageClient/api.go
+++ b/storageClient/api.go
@@ -33,6 +33,7 @@ type EACP struct {
 	EmailEACP      *EmailEACP      `json:"email_eacp,omitempty"`
 	LastAccessEACP *LastAccessEACP `json:"last_access_eacp,omitempty"`
 	ToznyOTPEACP   *ToznyOTPEACP   `json:"tozny_otp_eacp,omitempty"`
+	TozIDEACP      *TozIDEACP      `json:"tozid_eacp,omitempty"`
 }
 
 type EmailEACP struct {
@@ -51,6 +52,10 @@ type LastAccessEACP struct {
 type ToznyOTPEACP struct {
 	Include bool `json:"include"`
 }
+
+// TozIDEACP wraps an EACP requiring the proxying of a one time password OTP
+// embedded as the nonce claim for a valid & signed TozID realm auth JWT token
+type TozIDEACP struct{}
 
 type BulkDeleteResponse struct {
 	ClientID    uuid.UUID `json:"client_id"`
@@ -80,9 +85,33 @@ type PrimeResponseBody struct {
 
 type ChallengeRequest struct {
 	EmailEACPChallenge EmailEACPChallengeRequest `json:"email_eacp"`
+	TozIDEACPChallenge TozIDEACPChallengeRequest `json:"tozid_eacp"`
 }
 
 type EmailEACPChallengeRequest struct {
 	TemplateName string `json:"template_name"`
 	OTPRequest
+}
+
+// TozIDEACPChallengeRequest wraps parameters needed to activate a TozID EACP on a note.
+type TozIDEACPChallengeRequest struct {
+	ExpirySeconds int64 `json:"expiry_seconds"`
+}
+
+// ChallengeResponse wraps parameters for all activated challenges on a note.
+type ChallengeResponse struct {
+	EmailEACPChallenge *EmailEACPChallengeResponse `json:"email_eacp,omitempty"`
+	TozIDEACPChallenge *TozIDEACPChallengeResponse `json:"tozid_eacp,omitemtpy"`
+}
+
+type EmailEACPChallengeResponse struct {
+	ExpiresAt    time.Time `json:"expires_at"`
+	TemplateName string    `json:"template_name"`
+}
+
+// TozIDEACPChallengeRequest wraps parameters for an activated TozID EACP on a note.
+type TozIDEACPChallengeResponse struct {
+	ExpiresAt time.Time `json:"expires_at"`
+	// The `nonce` claim that must be present in a TozID JWT signed OIDC ID token issued as part of a valid TozID realm login session that also contains TozID as the authorizing party (`azp`) claim.
+	TozIDLoginTokenNonce string `json:"tozid_login_token_nonce"`
 }

--- a/storageClient/storageClient.go
+++ b/storageClient/storageClient.go
@@ -11,6 +11,12 @@ import (
 
 const (
 	storageServiceBasePath = "/v2/storage"
+	EmailOTPQueryParam     = "email_otp"
+	ToznyOTPQueryParam     = "tozny_otp"
+	// The TozID JWT signed OIDC ID token issued as part of a valid TozID realm login session that contains the one time password as the `nonce` claim and TozID as the authorizing party (`azp`) claim.
+	TozIDLoginTokenNonceQueryParam = "tozid_login_token_nonce"
+	// The TozID realm to verify the token specified by `tozid_login_token_nonce` is signed by.
+	TozIDLoginTokenRealmQueryParam = "tozid_login_token_realm"
 )
 
 //StorageClient implements an http client for communication with the metrics service.
@@ -62,10 +68,10 @@ func (c *StorageClient) ReadNote(ctx context.Context, noteID string, eacpParams 
 	return result, err
 }
 
-func (c *StorageClient) Challenge(ctx context.Context, noteID string, params ChallengeRequest) ([]string, error) {
+func (c *StorageClient) Challenge(ctx context.Context, noteID string, params ChallengeRequest) (ChallengeResponse, error) {
+	var challenges ChallengeResponse
 	path := c.Host + storageServiceBasePath + "/notes/challenge"
 	request, err := e3dbClients.CreateRequest("PATCH", path, params)
-	var challenges []string
 	if err != nil {
 		return challenges, err
 	}


### PR DESCRIPTION
- Update storageClient API definitions for activate challenge endpoint to include more fully specified activated challenges.
- Fix identity api struct semantic error.