### PR TITLE
Add internal ldap cache endpoints to identity client

### DIFF
--- a/identityClient/api.go
+++ b/identityClient/api.go
@@ -208,14 +208,24 @@ type CompleteChallengeRequest struct {
 	SignedTime      int64  `json:"sign_time"`        // time challenge was signed
 }
 
+// LDAPCache wraps the LDAP JSON data passed between services for caching
 type LDAPCache struct {
-	ID                 string              `json:"id,pk"`
-	LDAPID             string              `json:"ldap_id"`
-	DN                 string              `json:"dn"`
-	RdnAttributeName   string              `json:"rdn_attribute_name"`
-	Classes            []string            `json:"classes"`
-	Attributes         map[string][]string `json:"attributes"`
-	ReadOnlyAttributes []string            `json:"read_only_attributes"`
-	Groups             []string            `json:"groups"`
-	Roles              []string            `json:"roles"`
+	// User's Keycloak ID
+	ID string `json:"id,pk"`
+	// User's LDAP UUID (assigned by the LDAP server)
+	LDAPID string `json:"ldap_id"`
+	// The domain query used to find the user in the LDAP server
+	DN string `json:"dn"`
+	// Relative Distinguished Name addresses this specific user relative to the DN
+	RdnAttributeName string `json:"rdn_attribute_name"`
+	// Used to define what type of LDAP object this is
+	Classes []string `json:"classes"`
+	// Information about the LDAP object in key -> multi-value pairs
+	Attributes map[string][]string `json:"attributes"`
+	// Attribute keys which should not be writable
+	ReadOnlyAttributes []string `json:"read_only_attributes"`
+	// A set of Keycloak group IDs the user had at the time of caching
+	Groups []string `json:"groups"`
+	// A set of Keycloak role IDs the user had at the time of caching
+	Roles []string `json:"roles"`
 }

--- a/identityClient/api.go
+++ b/identityClient/api.go
@@ -207,3 +207,15 @@ type CompleteChallengeRequest struct {
 	SignedChallenge string `json:"signed_challenge"` // signed challenge in the form of "{challenge}{timestamp}"
 	SignedTime      int64  `json:"sign_time"`        // time challenge was signed
 }
+
+type LDAPCache struct {
+	ID                 string              `json:"id,pk"`
+	LDAPID             string              `json:"ldap_id"`
+	DN                 string              `json:"dn"`
+	RdnAttributeName   string              `json:"rdn_attribute_name"`
+	Classes            []string            `json:"classes"`
+	Attributes         map[string][]string `json:"attributes"`
+	ReadOnlyAttributes []string            `json:"read_only_attributes"`
+	Groups             []string            `json:"groups"`
+	Roles              []string            `json:"roles"`
+}

--- a/identityClient/identityClient.go
+++ b/identityClient/identityClient.go
@@ -139,6 +139,40 @@ func (c *E3dbIdentityClient) InternalDeleteIdentity(ctx context.Context, realmNa
 	return err
 }
 
+// InternalSetLDAPCache stores LDAP information for a specific user by ID in a specific realm
+func (c *E3dbIdentityClient) InternalSetLDAPCache(ctx context.Context, realmName string, params LDAPCache) error {
+	path := c.Host + internalIdentityServiceBasePath + "/keycloak/" + realmName + "/ldap-cache"
+	request, err := e3dbClients.CreateRequest(http.MethodPost, path, params)
+	if err != nil {
+		return err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	return err
+}
+
+// InternalLDAPCache gets LDAP information for a specific user by ID in a specific realm
+func (c *E3dbIdentityClient) InternalLDAPCache(ctx context.Context, realmName string, keycloakUserID string) (LDAPCache, error) {
+	var response LDAPCache
+	path := c.Host + internalIdentityServiceBasePath + "/keycloak/" + realmName + "/ldap-cache/" + keycloakUserID
+	request, err := e3dbClients.CreateRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return response, err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &response)
+	return response, err
+}
+
+// InternalDeleteLDAPCache removes LDAP information for a specific user by ID in a specific realm
+func (c *E3dbIdentityClient) InternalDeleteLDAPCache(ctx context.Context, realmName string, keycloakUserID string) error {
+	path := c.Host + internalIdentityServiceBasePath + "/keycloak/" + realmName + "/ldap-cache/" + keycloakUserID
+	request, err := e3dbClients.CreateRequest(http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	return err
+}
+
 // RegisterIdentity registers an identity with the specified realm using the specified parameters,
 // returning the created identity and error (if any).
 func (c *E3dbIdentityClient) RegisterIdentity(ctx context.Context, params RegisterIdentityRequest) (*RegisterIdentityResponse, error) {

--- a/identityClient/identityClient_test.go
+++ b/identityClient/identityClient_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 var (
-	toznyCyclopsHost            = utils.MustGetenv("TOZNY_CYCLOPS_SERVICE_HOST")
-	internalIdentityServiceHost = utils.MustGetenv("E3DB_IDENTITY_SERVICE_HOST")
-	e3dbAuthHost                = utils.MustGetenv("E3DB_AUTH_SERVICE_HOST")
-	e3dbAccountHost             = utils.MustGetenv("E3DB_ACCOUNT_SERVICE_HOST")
-	e3dbAPIKey                  = utils.MustGetenv("E3DB_API_KEY_ID")
-	e3dbAPISecret               = utils.MustGetenv("E3DB_API_KEY_SECRET")
-	e3dbClientID                = utils.MustGetenv("E3DB_CLIENT_ID")
-	bootstrapPublicSigningKey   = utils.MustGetenv("BOOTSTRAP_CLIENT_PUBLIC_SIGNING_KEY")
-	bootstrapPrivateSigningKey  = utils.MustGetenv("BOOTSTRAP_CLIENT_PRIVATE_SIGNING_KEY")
+	toznyCyclopsHost            = os.Getenv("TOZNY_CYCLOPS_SERVICE_HOST")
+	internalIdentityServiceHost = os.Getenv("E3DB_IDENTITY_SERVICE_HOST")
+	e3dbAuthHost                = os.Getenv("E3DB_AUTH_SERVICE_HOST")
+	e3dbAccountHost             = os.Getenv("E3DB_ACCOUNT_SERVICE_HOST")
+	e3dbAPIKey                  = os.Getenv("E3DB_API_KEY_ID")
+	e3dbAPISecret               = os.Getenv("E3DB_API_KEY_SECRET")
+	e3dbClientID                = os.Getenv("E3DB_CLIENT_ID")
+	bootstrapPublicSigningKey   = os.Getenv("BOOTSTRAP_CLIENT_PUBLIC_SIGNING_KEY")
+	bootstrapPrivateSigningKey  = os.Getenv("BOOTSTRAP_CLIENT_PRIVATE_SIGNING_KEY")
 	ValidAccountClientConfig    = e3dbClients.ClientConfig{
 		APIKey:    e3dbAPIKey,
 		APISecret: e3dbAPISecret,

--- a/identityClient/identityClient_test.go
+++ b/identityClient/identityClient_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 var (
-	toznyCyclopsHost            = os.Getenv("TOZNY_CYCLOPS_SERVICE_HOST")
-	internalIdentityServiceHost = os.Getenv("E3DB_IDENTITY_SERVICE_HOST")
-	e3dbAuthHost                = os.Getenv("E3DB_AUTH_SERVICE_HOST")
-	e3dbAccountHost             = os.Getenv("E3DB_ACCOUNT_SERVICE_HOST")
-	e3dbAPIKey                  = os.Getenv("E3DB_API_KEY_ID")
-	e3dbAPISecret               = os.Getenv("E3DB_API_KEY_SECRET")
-	e3dbClientID                = os.Getenv("E3DB_CLIENT_ID")
-	bootstrapPublicSigningKey   = os.Getenv("BOOTSTRAP_CLIENT_PUBLIC_SIGNING_KEY")
-	bootstrapPrivateSigningKey  = os.Getenv("BOOTSTRAP_CLIENT_PRIVATE_SIGNING_KEY")
+	toznyCyclopsHost            = utils.MustGetenv("TOZNY_CYCLOPS_SERVICE_HOST")
+	internalIdentityServiceHost = utils.MustGetenv("E3DB_IDENTITY_SERVICE_HOST")
+	e3dbAuthHost                = utils.MustGetenv("E3DB_AUTH_SERVICE_HOST")
+	e3dbAccountHost             = utils.MustGetenv("E3DB_ACCOUNT_SERVICE_HOST")
+	e3dbAPIKey                  = utils.MustGetenv("E3DB_API_KEY_ID")
+	e3dbAPISecret               = utils.MustGetenv("E3DB_API_KEY_SECRET")
+	e3dbClientID                = utils.MustGetenv("E3DB_CLIENT_ID")
+	bootstrapPublicSigningKey   = utils.MustGetenv("BOOTSTRAP_CLIENT_PUBLIC_SIGNING_KEY")
+	bootstrapPrivateSigningKey  = utils.MustGetenv("BOOTSTRAP_CLIENT_PRIVATE_SIGNING_KEY")
 	ValidAccountClientConfig    = e3dbClients.ClientConfig{
 		APIKey:    e3dbAPIKey,
 		APISecret: e3dbAPISecret,
@@ -52,6 +52,7 @@ var (
 	anonymousIdentityServiceClient = New(ValidIdentityClientConfig)
 	testContext                    = context.TODO()
 	accountServiceClient           = accountClient.New(ValidAccountClientConfig)
+	bootstrapClient                = New(BootIdentityClientConfig)
 )
 
 func TestHealthCheckPassesIfServiceIsRunning(t *testing.T) {
@@ -356,6 +357,154 @@ func TestInternalIdentityLoginWithAuthenticatedRealmIdentity(t *testing.T) {
 	}
 	if internalIdentityAuthenticationContext.RealmID != realm.ID || internalIdentityAuthenticationContext.RealmName != realm.Name || internalIdentityAuthenticationContext.Active != true {
 		t.Fatalf("expected registered identity %+v to be an active member of realm %+v , got  %+v", identity.Identity, realm, internalIdentityAuthenticationContext)
+	}
+}
+
+func TestInternalLDAPCacheCRUD(t *testing.T) {
+	accountTag := uuid.New().String()
+	queenClientInfo, _, err := test.MakeE3DBAccount(t, &accountServiceClient, accountTag, e3dbAuthHost)
+	if err != nil {
+		t.Fatalf("Error %q making new account", err)
+	}
+	queenClientInfo.Host = e3dbIdentityHost
+	identityServiceClient := New(queenClientInfo)
+	realmName := "TestInternalLDAPCrud"
+	sovereignName := "Yassqueen"
+	params := CreateRealmRequest{
+		RealmName:     realmName,
+		SovereignName: sovereignName,
+	}
+	realm, err := identityServiceClient.CreateRealm(testContext, params)
+	if err != nil {
+		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
+	}
+	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
+	// Set up test LDAP data
+	expectedLDAPData := LDAPCache{
+		ID:               uuid.New().String(),
+		LDAPID:           uuid.New().String(),
+		DN:               "cn=users,dn=tozny,dn=test",
+		RdnAttributeName: "cn",
+		Classes:          []string{"test", "of", "classes"},
+		Attributes: map[string][]string{
+			"cn":       []string{"testuser"},
+			"multi":    []string{"multiple", "values"},
+			"editable": []string{"this is editable"},
+		},
+		ReadOnlyAttributes: []string{"multi"},
+		Groups:             []string{"group1", "group2"},
+		Roles:              []string{"role1", "role2", "role3"},
+	}
+	err = bootstrapClient.InternalSetLDAPCache(testContext, realmName, expectedLDAPData)
+	if err != nil {
+		t.Fatalf("%v setting LDAP cache in %q realm with data %+v", err, realmName, expectedLDAPData)
+	}
+	// Fetch LDAP test data
+	fetchedData, err := bootstrapClient.InternalLDAPCache(testContext, realmName, expectedLDAPData.ID)
+	if err != nil {
+		t.Fatalf("%v getting LDAP cache in %q realm for ID %q", err, realmName, expectedLDAPData.ID)
+	}
+	// Validate response
+	if fetchedData.ID != expectedLDAPData.ID {
+		t.Errorf("User ID in LDAP cache doesn't match -- expected %q received %q", expectedLDAPData.ID, fetchedData.ID)
+	}
+	if fetchedData.LDAPID != expectedLDAPData.LDAPID {
+		t.Errorf("User LDAP ID in LDAP cache doesn't match -- expected %q received %q", expectedLDAPData.LDAPID, fetchedData.LDAPID)
+	}
+	if fetchedData.DN != expectedLDAPData.DN {
+		t.Errorf("User LDAP DN in LDAP cache doesn't match -- expected %q received %q", expectedLDAPData.DN, fetchedData.DN)
+	}
+	if fetchedData.RdnAttributeName != expectedLDAPData.RdnAttributeName {
+		t.Errorf("User RdnAttributename in LDAP cache doesn't match -- expected %q received %q", expectedLDAPData.RdnAttributeName, fetchedData.RdnAttributeName)
+	}
+	if len(fetchedData.Classes) != len(expectedLDAPData.Classes) {
+		t.Errorf("Length of user LDAP classes did not match -- expected %d received %d", len(expectedLDAPData.Classes), len(fetchedData.Classes))
+	}
+	for c := range fetchedData.Classes {
+		found := false
+		for f := range expectedLDAPData.Classes {
+			if c == f {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Missing class in class list of user LDAP classes -- looked for %q in %+v", c, expectedLDAPData.Classes)
+		}
+	}
+	if len(fetchedData.Groups) != len(expectedLDAPData.Groups) {
+		t.Errorf("Length of user LDAP groups did not match -- expected %d received %d", len(expectedLDAPData.Groups), len(fetchedData.Groups))
+	}
+	for c := range fetchedData.Groups {
+		found := false
+		for f := range expectedLDAPData.Groups {
+			if c == f {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Missing group in group list of user LDAP groups -- looked for %q in %+v", c, expectedLDAPData.Groups)
+		}
+	}
+	if len(fetchedData.Roles) != len(expectedLDAPData.Roles) {
+		t.Errorf("Length of user LDAP roles did not match -- expected %d received %d", len(expectedLDAPData.Roles), len(fetchedData.Roles))
+	}
+	for c := range fetchedData.Roles {
+		found := false
+		for f := range expectedLDAPData.Roles {
+			if c == f {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Missing role in role list of user LDAP roles -- looked for %q in %+v", c, expectedLDAPData.Roles)
+		}
+	}
+	if len(fetchedData.ReadOnlyAttributes) != len(expectedLDAPData.ReadOnlyAttributes) {
+		t.Errorf("Length of user LDAP read only attributes did not match -- expected %d received %d", len(expectedLDAPData.ReadOnlyAttributes), len(fetchedData.ReadOnlyAttributes))
+	}
+	for c := range fetchedData.ReadOnlyAttributes {
+		found := false
+		for f := range expectedLDAPData.ReadOnlyAttributes {
+			if c == f {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Missing read only attribute in list of user LDAP read only attributes -- looked for %q in %+v", c, expectedLDAPData.ReadOnlyAttributes)
+		}
+	}
+	if len(fetchedData.Attributes) != len(expectedLDAPData.Attributes) {
+		t.Errorf("Length of user LDAP attributes did not match -- expected %d received %d", len(expectedLDAPData.Attributes), len(fetchedData.Attributes))
+	}
+	for name, attrs := range fetchedData.Attributes {
+		expectedAttrs, ok := expectedLDAPData.Attributes[name]
+		if !ok {
+			t.Errorf("missing expected attribute %q in fetch attributes %+v", name, expectedLDAPData.Attributes)
+		}
+		if len(expectedAttrs) != len(attrs) {
+			t.Errorf("Length of attribute list %q did not match -- expected %d received %d", name, len(expectedAttrs), len(attrs))
+		}
+		for c := range attrs {
+			found := false
+			for f := range expectedAttrs {
+				if c == f {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Missing item in attribute list %q of user LDAP read only attributes -- looked for %q in %+v", name, c, expectedAttrs)
+			}
+		}
+	}
+	// Clear the cache
+	err = bootstrapClient.InternalDeleteLDAPCache(testContext, realmName, expectedLDAPData.ID)
+	if err != nil {
+		t.Fatalf("%+v when trying to remove LDAP cache for user %q", err, expectedLDAPData.ID)
 	}
 }
 


### PR DESCRIPTION
Adds methods for interacting with the new LDAP cache endpoint in identity service.