### PR TITLE
Added accountClient v2 health and service checks

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,7 @@
 E3DB_AUTH_SERVICE_HOST=http://platform.local.tozny.com:8003
 E3DB_API_URL=http://platform.local.tozny.com
 E3DB_ACCOUNT_SERVICE_HOST=http://platform.local.tozny.com:8002
+E3DB_ACCOUNT2_SERVICE_HOST=http://platform.local.tozny.com:8012
 E3DB_STORAGE_SERVICE_HOST=http://platform.local.tozny.com:8001
 E3DB_CLIENT_SERVICE_HOST=http://platform.local.tozny.com:8003
 E3DB_HOOK_SERVICE_HOST=http://platform.local.tozny.com:8006

--- a/accountClient/accountClient.go
+++ b/accountClient/accountClient.go
@@ -11,11 +11,12 @@ import (
 	"github.com/tozny/e3db-clients-go/authClient"
 )
 
+// HTTP PATH prefix for calls to the e3db Account service for v1
 const (
-	AccountServiceBasePath = "v1/account" //HTTP PATH prefix for calls to the e3db Account service
+	AccountServiceBasePath = "v1/account"
 )
 
-//E3dbAccountClient implements an http client for communication with an e3db Account service.
+// E3dbAccountClient implements an http client for communication with an e3db Account service.
 type E3dbAccountClient struct {
 	APIKey    string
 	APISecret string
@@ -80,7 +81,7 @@ func (c *E3dbAccountClient) RegisterClient(ctx context.Context, params ClientReg
 	return result, err
 }
 
-// RegisterClient registers a client via a proxied call to client service by the account service.
+// ProxyiedRegisterClient registers a client via a proxied call to client service by the account service.
 // This method is intended for TESTING the functionality of the integrated client service. Not intended for future use.
 func (c *E3dbAccountClient) ProxyiedRegisterClient(ctx context.Context, params ProxiedClientRegistrationRequest) (*ProxiedClientRegisterationResponse, error) {
 	var result *ProxiedClientRegisterationResponse

--- a/accountClient/accountClientV2.go
+++ b/accountClient/accountClientV2.go
@@ -1,0 +1,56 @@
+package accountClient
+
+import (
+	"context"
+
+	e3dbClients "github.com/tozny/e3db-clients-go"
+	"github.com/tozny/e3db-clients-go/authClient"
+)
+
+// HTTP PATH prefix for calls to the e3db Account service for v2
+const (
+	AccountServiceV2BasePath = "v2/account"
+)
+
+// E3dbAccountClient implements an http client for communication with an e3db Account service.
+type E3dbAccountClientV2 struct {
+	APIKey    string
+	APISecret string
+	Host      string
+	*authClient.E3dbAuthClient
+}
+
+// ServiceCheck checks whether the account service V2 is up and working.
+// returning error if unable to connect service
+func (c *E3dbAccountClientV2) ServiceCheck(ctx context.Context) error {
+	path := c.Host + "/" + AccountServiceV2BasePath + "/servicecheck"
+	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, nil)
+	return err
+}
+
+// HealthCheck checks whether the account service V2 is up,
+// returning error if unable to connect to the service.
+func (c *E3dbAccountClientV2) HealthCheck(ctx context.Context) error {
+	path := c.Host + "/" + AccountServiceV2BasePath + "/healthcheck"
+	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, nil)
+	return err
+}
+
+// NewV2 returns a new E3dbAccountClient configured with the specified apiKey and apiSecret values.
+func NewV2(config e3dbClients.ClientConfig) E3dbAccountClientV2 {
+	authService := authClient.New(config)
+	return E3dbAccountClientV2{
+		config.APIKey,
+		config.APISecret,
+		config.Host,
+		&authService,
+	}
+}

--- a/accountClient/accountClient_test.go
+++ b/accountClient/accountClient_test.go
@@ -14,13 +14,19 @@ import (
 var (
 	e3dbAuthHost      = os.Getenv("E3DB_AUTH_SERVICE_HOST")
 	e3dbAccountHost   = os.Getenv("E3DB_ACCOUNT_SERVICE_HOST")
+	e3dbAccountHostV2 = os.Getenv("E3DB_ACCOUNT2_SERVICE_HOST")
 	e3dbAPIKey        = os.Getenv("E3DB_API_KEY_ID")
 	e3dbAPISecret     = os.Getenv("E3DB_API_KEY_SECRET")
-	e3dbClientID      = os.Getenv("E3DB_CLIENT_ID")
 	ValidClientConfig = e3dbClients.ClientConfig{
 		APIKey:    e3dbAPIKey,
 		APISecret: e3dbAPISecret,
 		Host:      e3dbAccountHost,
+		AuthNHost: e3dbAuthHost,
+	}
+	ValidClientConfigV2 = e3dbClients.ClientConfig{
+		APIKey:    e3dbAPIKey,
+		APISecret: e3dbAPISecret,
+		Host:      e3dbAccountHostV2,
 		AuthNHost: e3dbAuthHost,
 	}
 )

--- a/accountClient/api.go
+++ b/accountClient/api.go
@@ -97,7 +97,7 @@ type ProxiedClientRegisterationInfo struct {
 	Name        string            `json:"name"`
 	Type        string            `json:"type"`
 	PublicKeys  map[string]string `json:"public_key"`
-	SigningKeys map[string]string `json:"signing_key,omitemtpy"`
+	SigningKeys map[string]string `json:"signing_key,omitempty"`
 }
 
 // ProxiedClientRegisterationResponse wraps the client information for a newly registered client.
@@ -116,7 +116,7 @@ type ProxyiedRegisteredClient struct {
 	Enabled     bool              `json:"enabled"`
 	HasBackup   bool              `json:"has_backup"`
 	PublicKeys  map[string]string `json:"public_key"`
-	SigningKeys map[string]string `json:"signing_key,omitemtpy"`
+	SigningKeys map[string]string `json:"signing_key,omitempty"`
 	Meta        map[string]string `json:"meta,omitempty"`
 }
 


### PR DESCRIPTION
Eli & I decided to add HostV2 to the E3dbAccoundClient so that these tests can be done, but I would like feedback on how other people think this should be done.
We're thinking there are three options:
1. 1 client with hosts for v1 and v2
2. 2 different clients with 1 host each
3. 1 client with 1 host where checks are managed by Cyclops