### PR TITLE
Feature/interceptors

### DIFF
--- a/accountClient/accountClientV2.go
+++ b/accountClient/accountClientV2.go
@@ -2,9 +2,11 @@ package accountClient
 
 import (
 	"context"
+	"net/http"
 
 	e3dbClients "github.com/tozny/e3db-clients-go"
 	"github.com/tozny/e3db-clients-go/authClient"
+	"github.com/tozny/e3db-clients-go/request"
 )
 
 // HTTP PATH prefix for calls to the e3db Account service for v2
@@ -18,17 +20,18 @@ type E3dbAccountClientV2 struct {
 	APISecret string
 	Host      string
 	*authClient.E3dbAuthClient
+	requester request.Requester
 }
 
 // ServiceCheck checks whether the account service V2 is up and working.
 // returning error if unable to connect service
 func (c *E3dbAccountClientV2) ServiceCheck(ctx context.Context) error {
 	path := c.Host + "/" + AccountServiceV2BasePath + "/servicecheck"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, nil)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, nil)
 	return err
 }
 
@@ -36,11 +39,11 @@ func (c *E3dbAccountClientV2) ServiceCheck(ctx context.Context) error {
 // returning error if unable to connect to the service.
 func (c *E3dbAccountClientV2) HealthCheck(ctx context.Context) error {
 	path := c.Host + "/" + AccountServiceV2BasePath + "/healthcheck"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, nil)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, nil)
 	return err
 }
 
@@ -52,5 +55,6 @@ func NewV2(config e3dbClients.ClientConfig) E3dbAccountClientV2 {
 		config.APISecret,
 		config.Host,
 		&authService,
+		request.ApplyInterceptors(&http.Client{}, config.Interceptors...),
 	}
 }

--- a/accountClient/api.go
+++ b/accountClient/api.go
@@ -100,8 +100,8 @@ type ProxiedClientRegisterationInfo struct {
 	SigningKeys map[string]string `json:"signing_key,omitempty"`
 }
 
-// ProxiedClientRegisterationResponse wraps the client information for a newly registered client.
-type ProxiedClientRegisterationResponse struct {
+// ProxiedClientRegistrationResponse wraps the client information for a newly registered client.
+type ProxiedClientRegistrationResponse struct {
 	ProxyiedRegisteredClient
 	APISecret    string `json:"api_secret"`
 	RootClientID string

--- a/authClient/authClient.go
+++ b/authClient/authClient.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	e3dbClients "github.com/tozny/e3db-clients-go"
+	"github.com/tozny/e3db-clients-go/request"
 	"github.com/tozny/utils-go/server"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
@@ -25,7 +26,8 @@ type E3dbAuthClient struct {
 	APISecret    string
 	Host         string
 	oauth2Helper clientcredentials.Config
-	httpClient   *http.Client
+	tokenSource  oauth2.TokenSource
+	requester    request.Requester
 }
 
 // GetToken attempts to retrieve and return a valid oauth2 token based on the clients
@@ -41,11 +43,11 @@ func (c *E3dbAuthClient) ValidateToken(ctx context.Context, params ValidateToken
 	if err != nil {
 		return result, err
 	}
-	request, err := http.NewRequest("POST", c.Host+AuthServiceBasePath+"/validate", &buf)
+	req, err := http.NewRequest("POST", c.Host+AuthServiceBasePath+"/validate", &buf)
 	if err != nil {
 		return result, err
 	}
-	internalError := e3dbClients.MakeE3DBServiceCall(c, ctx, request, &result)
+	internalError := e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.TokenSource(), req, &result)
 	return result, internalError
 }
 
@@ -67,16 +69,16 @@ func (c *E3dbAuthClient) AuthenticateE3DBClient(ctx context.Context, token strin
 	return validateTokenResponse.ClientId, validateTokenResponse.Valid, err
 }
 
-// AuthHTTPClient returns an http client that can be used for
+// TokenSource returns an oauth2 TokenSource that can be used for
 // making requests to Tozny services that require bearer auth,
 // automatically fetching and refreshing the token as needed
-func (c *E3dbAuthClient) AuthHTTPClient() *http.Client {
-	if c.httpClient == nil {
+func (c *E3dbAuthClient) TokenSource() oauth2.TokenSource {
+	if c.tokenSource == nil {
 		// Use a background context as while token refreshing is driven by client actions
 		// it is state maintained server side
-		c.httpClient = c.oauth2Helper.Client(context.Background())
+		c.tokenSource = c.oauth2Helper.TokenSource(context.Background())
 	}
-	return c.httpClient
+	return c.tokenSource
 }
 
 // HealthCheck checks whether the auth service is up,
@@ -86,7 +88,7 @@ func (c *E3dbAuthClient) HealthCheck(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := e3dbClients.MakePublicCall(ctx, req, nil); err != nil { // run request to auth healthcheck
+	if err := e3dbClients.MakePublicCall(ctx, c.requester, req, nil); err != nil { // run request to auth healthcheck
 		return err
 	}
 	return nil
@@ -103,5 +105,6 @@ func New(config e3dbClients.ClientConfig) E3dbAuthClient {
 			ClientSecret: config.APISecret,
 			TokenURL:     fmt.Sprintf("%s%s/token", config.AuthNHost, AuthServiceBasePath),
 		},
+		requester: request.ApplyInterceptors(&http.Client{}, config.Interceptors...),
 	}
 }

--- a/billingClient/billingClient.go
+++ b/billingClient/billingClient.go
@@ -2,10 +2,12 @@ package billingclient
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/google/uuid"
 	e3dbClients "github.com/tozny/e3db-clients-go"
 	"github.com/tozny/e3db-clients-go/authClient"
+	"github.com/tozny/e3db-clients-go/request"
 )
 
 const (
@@ -18,122 +20,123 @@ type E3dbBillingClient struct {
 	APISecret string
 	Host      string
 	*authClient.E3dbAuthClient
+	requester request.Requester
 }
 
 func (b *E3dbBillingClient) CreateAndSubscribeCustomer(ctx context.Context, params CreateCustomerRequest) (*CreateCustomerResponse, error) {
 	var result *CreateCustomerResponse
 	path := b.Host + "/internal" + BillingServiceBasePath + "/create-customer"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return result, e3dbClients.NewError(err.Error(), path, 0)
 	}
-	err = e3dbClients.MakeE3DBServiceCall(b.E3dbAuthClient, ctx, request, &result)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, b.requester, b.E3dbAuthClient.TokenSource(), req, &result)
 	return result, err
 }
 
 func (b *E3dbBillingClient) InternalSubscriptionInfo(ctx context.Context, accountID uuid.UUID) (*InternalGetMeteredSubscriptionInfoResponse, error) {
 	var result *InternalGetMeteredSubscriptionInfoResponse
 	path := b.Host + "/internal" + BillingServiceBasePath + "/subscription-info/" + accountID.String()
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return result, e3dbClients.NewError(err.Error(), path, 0)
 	}
-	err = e3dbClients.MakeE3DBServiceCall(b.E3dbAuthClient, ctx, request, &result)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, b.requester, b.E3dbAuthClient.TokenSource(), req, &result)
 	return result, err
 }
 
 func (b *E3dbBillingClient) InternalSubscriptionStatus(ctx context.Context, accountID uuid.UUID) (*GetAccountStatusResponse, error) {
 	var result *GetAccountStatusResponse
 	path := b.Host + "/internal" + BillingServiceBasePath + "/subscription/status/" + accountID.String()
-	request, err := e3dbClients.CreateRequest("GET", path, accountID)
+	req, err := e3dbClients.CreateRequest("GET", path, accountID)
 	if err != nil {
 		return result, e3dbClients.NewError(err.Error(), path, 0)
 	}
-	err = e3dbClients.MakeE3DBServiceCall(b.E3dbAuthClient, ctx, request, &result)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, b.requester, b.E3dbAuthClient.TokenSource(), req, &result)
 	return result, err
 }
 
 func (b *E3dbBillingClient) AccountSubscriptionStatus(ctx context.Context) (*GetAccountStatusResponse, error) {
 	var result *GetAccountStatusResponse
 	path := b.Host + BillingServiceBasePath + "/subscription/status"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return result, e3dbClients.NewError(err.Error(), path, 0)
 	}
-	err = e3dbClients.MakeE3DBServiceCall(b.E3dbAuthClient, ctx, request, &result)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, b.requester, b.E3dbAuthClient.TokenSource(), req, &result)
 	return result, err
 }
 
 func (b *E3dbBillingClient) Unsubscribe(ctx context.Context) (*GetAccountStatusResponse, error) {
 	var result *GetAccountStatusResponse
 	path := b.Host + BillingServiceBasePath + "/unsubscribe"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return result, e3dbClients.NewError(err.Error(), path, 0)
 	}
-	err = e3dbClients.MakeE3DBServiceCall(b.E3dbAuthClient, ctx, request, &result)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, b.requester, b.E3dbAuthClient.TokenSource(), req, &result)
 	return result, err
 }
 
 func (b *E3dbBillingClient) Resubscribe(ctx context.Context) (*GetAccountStatusResponse, error) {
 	var result *GetAccountStatusResponse
 	path := b.Host + BillingServiceBasePath + "/resubscribe"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return result, e3dbClients.NewError(err.Error(), path, 0)
 	}
-	err = e3dbClients.MakeE3DBServiceCall(b.E3dbAuthClient, ctx, request, &result)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, b.requester, b.E3dbAuthClient.TokenSource(), req, &result)
 	return result, err
 }
 
 func (b *E3dbBillingClient) ListInvoices(ctx context.Context) (*ListInvoicesResponse, error) {
 	var result *ListInvoicesResponse
 	path := b.Host + BillingServiceBasePath + "/invoices"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return result, e3dbClients.NewError(err.Error(), path, 0)
 	}
-	err = e3dbClients.MakeE3DBServiceCall(b.E3dbAuthClient, ctx, request, &result)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, b.requester, b.E3dbAuthClient.TokenSource(), req, &result)
 	return result, err
 }
 
 func (b *E3dbBillingClient) UpdatePaymentSource(ctx context.Context, source UpdateSourceRequest) error {
 	path := b.Host + BillingServiceBasePath + "/payment-source"
-	request, err := e3dbClients.CreateRequest("POST", path, source)
+	req, err := e3dbClients.CreateRequest("POST", path, source)
 	if err != nil {
 		return e3dbClients.NewError(err.Error(), path, 0)
 	}
-	err = e3dbClients.MakeE3DBServiceCall(b.E3dbAuthClient, ctx, request, nil)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, b.requester, b.E3dbAuthClient.TokenSource(), req, nil)
 	return err
 }
 
 func (b *E3dbBillingClient) ApplyCoupon(ctx context.Context, coupon ApplyCouponRequest) error {
 	path := b.Host + BillingServiceBasePath + "/coupon"
-	request, err := e3dbClients.CreateRequest("POST", path, coupon)
+	req, err := e3dbClients.CreateRequest("POST", path, coupon)
 	if err != nil {
 		return e3dbClients.NewError(err.Error(), path, 0)
 	}
-	err = e3dbClients.MakeE3DBServiceCall(b.E3dbAuthClient, ctx, request, nil)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, b.requester, b.E3dbAuthClient.TokenSource(), req, nil)
 	return err
 }
 
 func (c *E3dbBillingClient) HealthCheck(ctx context.Context) error {
 	path := c.Host + BillingServiceBasePath + "/healthcheck"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, nil)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, nil)
 	return err
 }
 
 func (c *E3dbBillingClient) ServiceCheck(ctx context.Context) error {
 	path := c.Host + BillingServiceBasePath + "/servicecheck"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, nil)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, nil)
 	return err
 }
 
@@ -144,5 +147,6 @@ func New(config e3dbClients.ClientConfig) E3dbBillingClient {
 		config.APISecret,
 		config.Host,
 		&authService,
+		request.ApplyInterceptors(&http.Client{}, config.Interceptors...),
 	}
 }

--- a/hookClient/hookClient_test.go
+++ b/hookClient/hookClient_test.go
@@ -47,7 +47,7 @@ func TestCreateWebHook(t *testing.T) {
 	createHookRequest := CreateHookRequest{
 		WebhookURL: webhookURL,
 		Triggers: []HookTrigger{
-			HookTrigger{
+			{
 				Enabled:  true,
 				APIEvent: "authorizer_added",
 			},

--- a/identityClient/identityClient.go
+++ b/identityClient/identityClient.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	e3dbClients "github.com/tozny/e3db-clients-go"
+	"github.com/tozny/e3db-clients-go/request"
 	"github.com/tozny/utils-go/server"
 )
 
@@ -36,40 +37,40 @@ type E3dbIdentityClient struct {
 	Host        string
 	SigningKeys e3dbClients.SigningKeys
 	ClientID    string
-	httpClient  *http.Client
+	requester   request.Requester
 }
 
 // ListRealmApplicationMappers lists the applicationMappers for a given realm or error (if any).
 func (c *E3dbIdentityClient) ListRealmApplicationMappers(ctx context.Context, params ListRealmApplicationMappersRequest) (*ListRealmApplicationMappersResponse, error) {
 	var applicationMappers *ListRealmApplicationMappersResponse
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName + "/" + params.ApplicationID + "/" + applicationMapperResourceName
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return applicationMappers, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &applicationMappers)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &applicationMappers)
 	return applicationMappers, err
 }
 
 // DeleteRealmApplicationMapper deletes the specified realm application mapper, returning error (if any).
 func (c *E3dbIdentityClient) DeleteRealmApplicationMapper(ctx context.Context, params DeleteRealmApplicationMapperRequest) error {
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName + "/" + params.ApplicationID + "/" + applicationMapperResourceName + "/" + params.ApplicationMapperID
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	return e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	return e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 }
 
 // DescribeRealmApplicationMapper describes the realm application mapper with the specified id, returning the application mapper or error (if any).
 func (c *E3dbIdentityClient) DescribeRealmApplicationMapper(ctx context.Context, params DescribeRealmApplicationMapperRequest) (*ApplicationMapper, error) {
 	var applicationMapper *ApplicationMapper
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName + "/" + params.ApplicationID + "/" + applicationMapperResourceName + "/" + params.ApplicationMapperID
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return applicationMapper, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &applicationMapper)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &applicationMapper)
 	return applicationMapper, err
 }
 
@@ -78,11 +79,11 @@ func (c *E3dbIdentityClient) DescribeRealmApplicationMapper(ctx context.Context,
 func (c *E3dbIdentityClient) CreateRealmApplicationMapper(ctx context.Context, params CreateRealmApplicationMapperRequest) (*ApplicationMapper, error) {
 	var applicationMapper *ApplicationMapper
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName + "/" + params.ApplicationID + "/" + applicationMapperResourceName
-	request, err := e3dbClients.CreateRequest("POST", path, params.ApplicationMapper)
+	req, err := e3dbClients.CreateRequest("POST", path, params.ApplicationMapper)
 	if err != nil {
 		return applicationMapper, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &applicationMapper)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &applicationMapper)
 	return applicationMapper, err
 }
 
@@ -90,11 +91,11 @@ func (c *E3dbIdentityClient) CreateRealmApplicationMapper(ctx context.Context, p
 func (c *E3dbIdentityClient) FetchApplicationSecret(ctx context.Context, params FetchApplicationSecretRequest) (*ApplicationSecret, error) {
 	var secret *ApplicationSecret
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName + "/" + params.ApplicationID + "/secret"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return secret, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &secret)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &secret)
 	return secret, err
 }
 
@@ -102,11 +103,11 @@ func (c *E3dbIdentityClient) FetchApplicationSecret(ctx context.Context, params 
 func (c *E3dbIdentityClient) FetchApplicationSAMLDescription(ctx context.Context, params FetchApplicationSAMLDescriptionRequest) (*ApplicationSAMLDescription, error) {
 	var description *ApplicationSAMLDescription
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName + "/" + params.ApplicationID + "/installation/providers/" + params.Format
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return description, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &description)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &description)
 	return description, err
 }
 
@@ -114,33 +115,33 @@ func (c *E3dbIdentityClient) FetchApplicationSAMLDescription(ctx context.Context
 func (c *E3dbIdentityClient) ListRealmRoles(ctx context.Context, realmName string) (*ListRealmRolesResponse, error) {
 	var roles *ListRealmRolesResponse
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + realmName + "/" + roleResourceName
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return roles, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &roles)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &roles)
 	return roles, err
 }
 
 // DeleteRealmRole deletes the specified realm role, returning error (if any).
 func (c *E3dbIdentityClient) DeleteRealmRole(ctx context.Context, params DeleteRealmRoleRequest) error {
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + roleResourceName + "/" + params.RoleID
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	return e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	return e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 }
 
 // DescribeRealmRole describes the realm role with the specified id, returning the role or error (if any).
 func (c *E3dbIdentityClient) DescribeRealmRole(ctx context.Context, params DescribeRealmRoleRequest) (*Role, error) {
 	var role *Role
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + roleResourceName + "/" + params.RoleID
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return role, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &role)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &role)
 	return role, err
 }
 
@@ -149,11 +150,11 @@ func (c *E3dbIdentityClient) DescribeRealmRole(ctx context.Context, params Descr
 func (c *E3dbIdentityClient) CreateRealmRole(ctx context.Context, params CreateRealmRoleRequest) (*Role, error) {
 	var role *Role
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + roleResourceName
-	request, err := e3dbClients.CreateRequest("POST", path, params.Role)
+	req, err := e3dbClients.CreateRequest("POST", path, params.Role)
 	if err != nil {
 		return role, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &role)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &role)
 	return role, err
 }
 
@@ -161,11 +162,11 @@ func (c *E3dbIdentityClient) CreateRealmRole(ctx context.Context, params CreateR
 func (c *E3dbIdentityClient) ListGroupRoleMappings(ctx context.Context, params ListGroupRoleMappingsRequest) (*RoleMapping, error) {
 	var roleMappings *RoleMapping
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + groupResourceName + "/" + params.GroupID + "/" + roleMapperResourceName
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return roleMappings, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &roleMappings)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &roleMappings)
 	return roleMappings, err
 }
 
@@ -173,37 +174,37 @@ func (c *E3dbIdentityClient) ListGroupRoleMappings(ctx context.Context, params L
 // returning nil on success or error (if any).
 func (c *E3dbIdentityClient) RemoveGroupRoleMappings(ctx context.Context, params RemoveGroupRoleMappingsRequest) error {
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + groupResourceName + "/" + params.GroupID + "/" + roleMapperResourceName
-	request, err := e3dbClients.CreateRequest("DELETE", path, params.RoleMapping)
+	req, err := e3dbClients.CreateRequest("DELETE", path, params.RoleMapping)
 	if err != nil {
 		return err
 	}
-	return e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	return e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 }
 
 // AddGroupRoleMappings adds the specified role mappings to the group
 // returning nil on success or error (if any).
 func (c *E3dbIdentityClient) AddGroupRoleMappings(ctx context.Context, params AddGroupRoleMappingsRequest) error {
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + groupResourceName + "/" + params.GroupID + "/" + roleMapperResourceName
-	request, err := e3dbClients.CreateRequest("POST", path, params.RoleMapping)
+	req, err := e3dbClients.CreateRequest("POST", path, params.RoleMapping)
 	if err != nil {
 		return err
 	}
-	return e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	return e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 }
 
 // ListIdentities in a given realm in a paginated way.
 func (c *E3dbIdentityClient) ListIdentities(ctx context.Context, params ListIdentitiesRequest) (*ListIdentitiesResponse, error) {
 	var identities *ListIdentitiesResponse
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + identityResourceName
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return identities, err
 	}
-	urlParams := request.URL.Query()
+	urlParams := req.URL.Query()
 	urlParams.Set("first", strconv.Itoa(int(params.First)))
 	urlParams.Set("max", strconv.Itoa(int(params.Max)))
-	request.URL.RawQuery = urlParams.Encode()
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &identities)
+	req.URL.RawQuery = urlParams.Encode()
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &identities)
 	return identities, err
 }
 
@@ -211,11 +212,11 @@ func (c *E3dbIdentityClient) ListIdentities(ctx context.Context, params ListIden
 func (c *E3dbIdentityClient) DescribeIdentity(ctx context.Context, realmName string, clientID string) (*IdentityDetails, error) {
 	var identity *IdentityDetails
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + realmName + "/" + identityResourceName + "/" + clientID
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return identity, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &identity)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &identity)
 	return identity, err
 }
 
@@ -223,33 +224,33 @@ func (c *E3dbIdentityClient) DescribeIdentity(ctx context.Context, realmName str
 func (c *E3dbIdentityClient) ListRealmProviderMappers(ctx context.Context, params ListRealmProviderMappersRequest) (*ListRealmProviderMappersResponse, error) {
 	var providerMappers *ListRealmProviderMappersResponse
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + providerResourceName + "/" + params.ProviderID + "/" + providerMapperResourceName
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return providerMappers, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &providerMappers)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &providerMappers)
 	return providerMappers, err
 }
 
 // DeleteRealmProviderMapper deletes the specified realm provider mapper, returning error (if any).
 func (c *E3dbIdentityClient) DeleteRealmProviderMapper(ctx context.Context, params DeleteRealmProviderMapperRequest) error {
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + providerResourceName + "/" + params.ProviderID + "/" + providerMapperResourceName + "/" + params.ProviderMapperID
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	return e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	return e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 }
 
 // DescribeRealmProviderMapper describes the realm provider mapper with the specified id, returning the provider mapper or error (if any).
 func (c *E3dbIdentityClient) DescribeRealmProviderMapper(ctx context.Context, params DescribeRealmProviderMapperRequest) (*ProviderMapper, error) {
 	var providerMapper *ProviderMapper
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + providerResourceName + "/" + params.ProviderID + "/" + providerMapperResourceName + "/" + params.ProviderMapperID
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return providerMapper, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &providerMapper)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &providerMapper)
 	return providerMapper, err
 }
 
@@ -258,11 +259,11 @@ func (c *E3dbIdentityClient) DescribeRealmProviderMapper(ctx context.Context, pa
 func (c *E3dbIdentityClient) CreateRealmProviderMapper(ctx context.Context, params CreateRealmProviderMapperRequest) (*ProviderMapper, error) {
 	var providerMapper *ProviderMapper
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + providerResourceName + "/" + params.ProviderID + "/" + providerMapperResourceName
-	request, err := e3dbClients.CreateRequest("POST", path, params.ProviderMapper)
+	req, err := e3dbClients.CreateRequest("POST", path, params.ProviderMapper)
 	if err != nil {
 		return providerMapper, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &providerMapper)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &providerMapper)
 	return providerMapper, err
 }
 
@@ -270,33 +271,33 @@ func (c *E3dbIdentityClient) CreateRealmProviderMapper(ctx context.Context, para
 func (c *E3dbIdentityClient) ListRealmProviders(ctx context.Context, realmName string) (*ListRealmProvidersResponse, error) {
 	var providers *ListRealmProvidersResponse
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + realmName + "/" + providerResourceName
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return providers, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &providers)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &providers)
 	return providers, err
 }
 
 // DeleteRealmProvider deletes the specified realm provider, returning error (if any).
 func (c *E3dbIdentityClient) DeleteRealmProvider(ctx context.Context, params DeleteRealmProviderRequest) error {
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + providerResourceName + "/" + params.ProviderID
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	return e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	return e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 }
 
 // DescribeRealmProvider describes the realm provider with the specified id, returning the provider or error (if any).
 func (c *E3dbIdentityClient) DescribeRealmProvider(ctx context.Context, params DescribeRealmProviderRequest) (*Provider, error) {
 	var provider *Provider
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + providerResourceName + "/" + params.ProviderID
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return provider, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &provider)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &provider)
 	return provider, err
 }
 
@@ -305,11 +306,11 @@ func (c *E3dbIdentityClient) DescribeRealmProvider(ctx context.Context, params D
 func (c *E3dbIdentityClient) CreateRealmProvider(ctx context.Context, params CreateRealmProviderRequest) (*Provider, error) {
 	var provider *Provider
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + providerResourceName
-	request, err := e3dbClients.CreateRequest("POST", path, params.Provider)
+	req, err := e3dbClients.CreateRequest("POST", path, params.Provider)
 	if err != nil {
 		return provider, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &provider)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &provider)
 	return provider, err
 }
 
@@ -317,33 +318,33 @@ func (c *E3dbIdentityClient) CreateRealmProvider(ctx context.Context, params Cre
 func (c *E3dbIdentityClient) ListRealmApplications(ctx context.Context, realmName string) (*ListRealmApplicationsResponse, error) {
 	var applications *ListRealmApplicationsResponse
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + realmName + "/" + applicationResourceName
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return applications, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &applications)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &applications)
 	return applications, err
 }
 
 // DeleteRealmApplication deletes the specified realm application, returning error (if any).
 func (c *E3dbIdentityClient) DeleteRealmApplication(ctx context.Context, params DeleteRealmApplicationRequest) error {
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName + "/" + params.ApplicationID
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	return e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	return e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 }
 
 // DescribeRealmApplication describes the realm application with the specified id, returning the application or error (if any).
 func (c *E3dbIdentityClient) DescribeRealmApplication(ctx context.Context, params DescribeRealmApplicationRequest) (*Application, error) {
 	var application *Application
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName + "/" + params.ApplicationID
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return application, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &application)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &application)
 	return application, err
 }
 
@@ -352,11 +353,11 @@ func (c *E3dbIdentityClient) DescribeRealmApplication(ctx context.Context, param
 func (c *E3dbIdentityClient) CreateRealmApplication(ctx context.Context, params CreateRealmApplicationRequest) (*Application, error) {
 	var application *Application
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName
-	request, err := e3dbClients.CreateRequest("POST", path, params.Application)
+	req, err := e3dbClients.CreateRequest("POST", path, params.Application)
 	if err != nil {
 		return application, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &application)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &application)
 	return application, err
 }
 
@@ -364,33 +365,33 @@ func (c *E3dbIdentityClient) CreateRealmApplication(ctx context.Context, params 
 func (c *E3dbIdentityClient) ListRealmApplicationRoles(ctx context.Context, params ListRealmApplicationRolesRequest) (*ListRealmApplicationRolesResponse, error) {
 	var applicationRoles *ListRealmApplicationRolesResponse
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName + "/" + params.ApplicationID + "/" + roleResourceName
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return applicationRoles, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &applicationRoles)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &applicationRoles)
 	return applicationRoles, err
 }
 
 // DeleteRealmApplicationRole deletes the specified realm application role, returning error (if any).
 func (c *E3dbIdentityClient) DeleteRealmApplicationRole(ctx context.Context, params DeleteRealmApplicationRoleRequest) error {
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName + "/" + params.ApplicationID + "/" + roleResourceName + "/" + url.QueryEscape(params.ApplicationRoleName)
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	return e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	return e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 }
 
 // DescribeRealmApplicationRole describes the realm application role with the specified id, returning the application or error (if any).
 func (c *E3dbIdentityClient) DescribeRealmApplicationRole(ctx context.Context, params DescribeRealmApplicationRoleRequest) (*ApplicationRole, error) {
 	var applicationRole *ApplicationRole
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName + "/" + params.ApplicationID + "/" + roleResourceName + "/" + url.QueryEscape(params.ApplicationRoleName)
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return applicationRole, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &applicationRole)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &applicationRole)
 	return applicationRole, err
 }
 
@@ -399,11 +400,11 @@ func (c *E3dbIdentityClient) DescribeRealmApplicationRole(ctx context.Context, p
 func (c *E3dbIdentityClient) CreateRealmApplicationRole(ctx context.Context, params CreateRealmApplicationRoleRequest) (*ApplicationRole, error) {
 	var applicationRole *ApplicationRole
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + applicationResourceName + "/" + params.ApplicationID + "/" + roleResourceName
-	request, err := e3dbClients.CreateRequest("POST", path, params.ApplicationRole)
+	req, err := e3dbClients.CreateRequest("POST", path, params.ApplicationRole)
 	if err != nil {
 		return applicationRole, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &applicationRole)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &applicationRole)
 	return applicationRole, err
 }
 
@@ -411,33 +412,33 @@ func (c *E3dbIdentityClient) CreateRealmApplicationRole(ctx context.Context, par
 func (c *E3dbIdentityClient) ListRealmGroups(ctx context.Context, params ListRealmGroupsRequest) (*ListRealmGroupsResponse, error) {
 	var groups *ListRealmGroupsResponse
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + groupResourceName
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return groups, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &groups)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &groups)
 	return groups, err
 }
 
 // DeleteRealmGroup deletes the specified realm group, returning error (if any).
 func (c *E3dbIdentityClient) DeleteRealmGroup(ctx context.Context, params DeleteRealmGroupRequest) error {
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + groupResourceName + "/" + params.GroupID
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	return e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	return e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 }
 
 // DescribeRealmGroup describes the realm group with the specified id, returning the realm group or error (if any).
 func (c *E3dbIdentityClient) DescribeRealmGroup(ctx context.Context, params DescribeRealmGroupRequest) (*Group, error) {
 	var group *Group
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + groupResourceName + "/" + params.GroupID
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return group, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &group)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &group)
 	return group, err
 }
 
@@ -446,11 +447,11 @@ func (c *E3dbIdentityClient) DescribeRealmGroup(ctx context.Context, params Desc
 func (c *E3dbIdentityClient) CreateRealmGroup(ctx context.Context, params CreateRealmGroupRequest) (*Group, error) {
 	var group *Group
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + groupResourceName
-	request, err := e3dbClients.CreateRequest("POST", path, params.Group)
+	req, err := e3dbClients.CreateRequest("POST", path, params.Group)
 	if err != nil {
 		return group, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &group)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &group)
 	return group, err
 }
 
@@ -458,25 +459,25 @@ func (c *E3dbIdentityClient) CreateRealmGroup(ctx context.Context, params Create
 func (c *E3dbIdentityClient) ListOIDCKeysForRealm(ctx context.Context, realmName string) (ListRealmOIDCKeysResponse, error) {
 	var listedKeys ListRealmOIDCKeysResponse
 	path := fmt.Sprintf("%s%s/%s/protocol/openid-connect/certs", c.Host, realmLoginPathPrefix, strings.ToLower(realmName))
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return listedKeys, err
 	}
-	err = e3dbClients.MakeRawServiceCall(c.httpClient, request, &listedKeys)
+	err = e3dbClients.MakeRawServiceCall(c.requester, req, &listedKeys)
 	if err != nil {
 		return listedKeys, err
 	}
 	return listedKeys, err
 }
 
-// BrokerIdentityChallange begins a broker-based login flow using the specified params, returning error (if any).
+// BrokerIdentityChallenge begins a broker-based login flow using the specified params, returning error (if any).
 func (c *E3dbIdentityClient) BrokerIdentityChallenge(ctx context.Context, params BrokerChallengeRequest) error {
 	path := c.Host + identityServiceBasePath + fmt.Sprintf("/broker/%s/%s/challenge", realmResourceName, params.RealmName)
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return err
 	}
-	return e3dbClients.MakeRawServiceCall(c.httpClient, request, nil)
+	return e3dbClients.MakeRawServiceCall(c.requester, req, nil)
 }
 
 // RegisterIdentity completes a broker based login flow by giving the broker the needed authentication
@@ -484,11 +485,11 @@ func (c *E3dbIdentityClient) BrokerIdentityChallenge(ctx context.Context, params
 func (c *E3dbIdentityClient) BrokerIdentityLogin(ctx context.Context, params BrokerLoginRequest) (*BrokerLoginResponse, error) {
 	var identity *BrokerLoginResponse
 	path := c.Host + identityServiceBasePath + fmt.Sprintf("/broker/%s/%s/login", realmResourceName, params.RealmName)
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return identity, err
 	}
-	err = e3dbClients.MakeRawServiceCall(c.httpClient, request, &identity)
+	err = e3dbClients.MakeRawServiceCall(c.requester, req, &identity)
 	return identity, err
 }
 
@@ -497,11 +498,11 @@ func (c *E3dbIdentityClient) BrokerIdentityLogin(ctx context.Context, params Bro
 func (c *E3dbIdentityClient) RegisterRealmBrokerIdentity(ctx context.Context, params RegisterRealmBrokerIdentityRequest) (*RegisterRealmBrokerIdentityResponse, error) {
 	var identity *RegisterRealmBrokerIdentityResponse
 	path := c.Host + identityServiceBasePath + fmt.Sprintf("/%s/%s/broker/identity", realmResourceName, strings.ToLower(params.RealmName))
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return identity, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &identity)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &identity)
 	return identity, err
 }
 
@@ -510,11 +511,11 @@ func (c *E3dbIdentityClient) RegisterRealmBrokerIdentity(ctx context.Context, pa
 func (c *E3dbIdentityClient) GetToznyHostedBrokerInfo(ctx context.Context) (*ToznyHostedBrokerInfoResponse, error) {
 	var toznyHostedBrokerInfo *ToznyHostedBrokerInfoResponse
 	path := c.Host + identityServiceBasePath + "/broker/info"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return toznyHostedBrokerInfo, err
 	}
-	err = e3dbClients.MakeRawServiceCall(c.httpClient, request, &toznyHostedBrokerInfo)
+	err = e3dbClients.MakeRawServiceCall(c.requester, req, &toznyHostedBrokerInfo)
 	return toznyHostedBrokerInfo, err
 }
 
@@ -529,12 +530,12 @@ func (c *E3dbIdentityClient) IdentityLogin(ctx context.Context, realmName string
 	data.Set("grant_type", "password")
 	// Not the actual realm admin, just an identity with API level access.
 	data.Set("client_id", "admin-cli")
-	request, err := http.NewRequest("POST", path, strings.NewReader(data.Encode()))
+	req, err := http.NewRequest("POST", path, strings.NewReader(data.Encode()))
 	if err != nil {
 		return identity, err
 	}
-	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &identity)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &identity)
 	return identity, err
 }
 
@@ -544,12 +545,12 @@ func (c *E3dbIdentityClient) IdentityLogin(ctx context.Context, realmName string
 func (c *E3dbIdentityClient) InternalIdentityLogin(ctx context.Context, params InternalIdentityLoginRequest) (*InternalIdentityLoginResponse, error) {
 	var identity *InternalIdentityLoginResponse
 	path := c.Host + internalIdentityServiceBasePath + fmt.Sprintf("/%s/%s", realmResourceName, params.RealmName) + "/login"
-	request, err := e3dbClients.CreateRequest("POST", path, nil)
+	req, err := e3dbClients.CreateRequest("POST", path, nil)
 	if err != nil {
 		return identity, err
 	}
-	request.Header.Set(server.ToznyAuthNHeader, params.XToznyAuthNHeader)
-	err = e3dbClients.MakeRawServiceCall(c.httpClient, request, &identity)
+	req.Header.Set(server.ToznyAuthNHeader, params.XToznyAuthNHeader)
+	err = e3dbClients.MakeRawServiceCall(c.requester, req, &identity)
 	return identity, err
 }
 
@@ -558,42 +559,42 @@ func (c *E3dbIdentityClient) InternalUpdateIdentityActiveByKeycloakUserID(ctx co
 	body := InternalUpdateActiveForKeycloakUserID{
 		Active: active,
 	}
-	request, err := e3dbClients.CreateRequest("PUT", path, &body)
+	req, err := e3dbClients.CreateRequest("PUT", path, &body)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 	return err
 }
 
 func (c *E3dbIdentityClient) InternalDeleteIdentity(ctx context.Context, realmName string, keycloakUserID string, username string) error {
 	path := c.Host + internalIdentityServiceBasePath + "/keycloak/user/" + realmName + "/" + keycloakUserID + "?username=" + username
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 	return err
 }
 
 func (c *E3dbIdentityClient) InternalDeleteIdentitiesByProvider(ctx context.Context, params InternalDeleteIdentitiesByProviderRequest) error {
 	path := c.Host + internalIdentityServiceBasePath + "/keycloak/" + params.RealmName + "/id-provider/" + params.ProviderID.String()
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 	return err
 }
 
 // InternalSetLDAPCache stores LDAP information for a specific user by ID in a specific realm
 func (c *E3dbIdentityClient) InternalSetLDAPCache(ctx context.Context, realmName string, params LDAPCache) error {
 	path := c.Host + internalIdentityServiceBasePath + "/keycloak/" + realmName + "/ldap-cache"
-	request, err := e3dbClients.CreateRequest(http.MethodPost, path, params)
+	req, err := e3dbClients.CreateRequest(http.MethodPost, path, params)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 	return err
 }
 
@@ -601,22 +602,22 @@ func (c *E3dbIdentityClient) InternalSetLDAPCache(ctx context.Context, realmName
 func (c *E3dbIdentityClient) InternalLDAPCache(ctx context.Context, realmName string, keycloakUserID string) (LDAPCache, error) {
 	var response LDAPCache
 	path := c.Host + internalIdentityServiceBasePath + "/keycloak/" + realmName + "/ldap-cache/" + keycloakUserID
-	request, err := e3dbClients.CreateRequest(http.MethodGet, path, nil)
+	req, err := e3dbClients.CreateRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return response, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &response)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &response)
 	return response, err
 }
 
 // InternalDeleteLDAPCache removes LDAP information for a specific user by ID in a specific realm
 func (c *E3dbIdentityClient) InternalDeleteLDAPCache(ctx context.Context, realmName string, keycloakUserID string) error {
 	path := c.Host + internalIdentityServiceBasePath + "/keycloak/" + realmName + "/ldap-cache/" + keycloakUserID
-	request, err := e3dbClients.CreateRequest(http.MethodDelete, path, nil)
+	req, err := e3dbClients.CreateRequest(http.MethodDelete, path, nil)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 	return err
 }
 
@@ -625,11 +626,11 @@ func (c *E3dbIdentityClient) InternalDeleteLDAPCache(ctx context.Context, realmN
 func (c *E3dbIdentityClient) RegisterIdentity(ctx context.Context, params RegisterIdentityRequest) (*RegisterIdentityResponse, error) {
 	var identity *RegisterIdentityResponse
 	path := c.Host + identityServiceBasePath + "/register"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return identity, err
 	}
-	err = e3dbClients.MakeRawServiceCall(c.httpClient, request, &identity)
+	err = e3dbClients.MakeRawServiceCall(c.requester, req, &identity)
 	return identity, err
 }
 
@@ -637,33 +638,33 @@ func (c *E3dbIdentityClient) RegisterIdentity(ctx context.Context, params Regist
 func (c *E3dbIdentityClient) ListRealms(ctx context.Context) (*ListRealmsResponse, error) {
 	var realms *ListRealmsResponse
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return realms, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &realms)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &realms)
 	return realms, err
 }
 
 // DeleteRealm deletes the realm with the specified name, returning error (if any).
 func (c *E3dbIdentityClient) DeleteRealm(ctx context.Context, realmName string) error {
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + fmt.Sprintf("/%s", realmName)
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	return e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	return e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 }
 
 // DescribeRealm describes the realm with the specified name, returning the realm and error (if any).
 func (c *E3dbIdentityClient) DescribeRealm(ctx context.Context, realmName string) (*Realm, error) {
 	var realm *Realm
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + fmt.Sprintf("/%s", realmName)
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return realm, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &realm)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &realm)
 	return realm, err
 }
 
@@ -672,66 +673,66 @@ func (c *E3dbIdentityClient) DescribeRealm(ctx context.Context, realmName string
 func (c *E3dbIdentityClient) CreateRealm(ctx context.Context, params CreateRealmRequest) (*Realm, error) {
 	var realm *Realm
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return realm, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &realm)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &realm)
 	return realm, err
 }
 
 func (c *E3dbIdentityClient) ChallengePushRequest(ctx context.Context, params UserChallengePushRequest) (InitiateUserChallengeResponse, error) {
 	var resp InitiateUserChallengeResponse
 	path := c.Host + internalIdentityServiceBasePath + "/keycloak/" + params.Realm + "/challenge/" + params.Username
-	request, err := e3dbClients.CreateRequest("PUT", path, params)
+	req, err := e3dbClients.CreateRequest("PUT", path, params)
 	if err != nil {
 		return resp, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &resp)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &resp)
 	return resp, err
 }
 
 func (c *E3dbIdentityClient) CompleteChallengeRequest(ctx context.Context, params CompleteChallengeRequest) error {
 	path := c.Host + identityServiceBasePath + "/challenge"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return err
 	}
 	client := &http.Client{}
-	err = e3dbClients.MakeRawServiceCall(client, request, nil)
+	err = e3dbClients.MakeRawServiceCall(client, req, nil)
 	return err
 }
 
 func (c *E3dbIdentityClient) InitiateRegisterUserDeviceRequest(ctx context.Context, params InitiateRegisterDeviceRequest) (InitiateRegisterDeviceResponse, error) {
 	var resp InitiateRegisterDeviceResponse
 	path := c.Host + identityServiceBasePath + "/register/device"
-	request, err := e3dbClients.CreateRequest("PUT", path, params)
+	req, err := e3dbClients.CreateRequest("PUT", path, params)
 	if err != nil {
 		return resp, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &resp)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &resp)
 	return resp, err
 }
 
 func (c *E3dbIdentityClient) CompleteRegisterUserDeviceRequest(ctx context.Context, params CompleteUserDeviceRegisterRequest) error {
 	path := c.Host + identityServiceBasePath + "/register/device"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return err
 	}
 	client := &http.Client{}
-	err = e3dbClients.MakeRawServiceCall(client, request, nil)
+	err = e3dbClients.MakeRawServiceCall(client, req, nil)
 	return err
 }
 
 func (c *E3dbIdentityClient) IsChallengeCompleteRequest(ctx context.Context, challengeID string) error {
 	path := c.Host + identityServiceBasePath + "/challenge/" + challengeID
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return err
 	}
 	client := &http.Client{}
-	err = e3dbClients.MakeRawServiceCall(client, request, nil)
+	err = e3dbClients.MakeRawServiceCall(client, req, nil)
 	return err
 }
 
@@ -739,11 +740,11 @@ func (c *E3dbIdentityClient) IsChallengeCompleteRequest(ctx context.Context, cha
 // returning error if unable to connect service
 func (c *E3dbIdentityClient) ServiceCheck(ctx context.Context) error {
 	path := c.Host + identityServiceBasePath + "/servicecheck"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeRawServiceCall(c.httpClient, request, nil)
+	err = e3dbClients.MakeRawServiceCall(c.requester, req, nil)
 	return err
 }
 
@@ -751,11 +752,11 @@ func (c *E3dbIdentityClient) ServiceCheck(ctx context.Context) error {
 // returning error if unable to connect to the service.
 func (c *E3dbIdentityClient) HealthCheck(ctx context.Context) error {
 	path := c.Host + identityServiceBasePath + "/healthcheck"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeRawServiceCall(c.httpClient, request, nil)
+	err = e3dbClients.MakeRawServiceCall(c.requester, req, nil)
 	return err
 }
 
@@ -765,6 +766,6 @@ func New(config e3dbClients.ClientConfig) E3dbIdentityClient {
 		Host:        config.Host,
 		SigningKeys: config.SigningKeys,
 		ClientID:    config.ClientID,
-		httpClient:  &http.Client{},
+		requester:   request.ApplyInterceptors(&http.Client{}, config.Interceptors...),
 	}
 }

--- a/identityClient/identityClient_test.go
+++ b/identityClient/identityClient_test.go
@@ -364,7 +364,7 @@ func TestInternalIdentityLoginWithAuthenticatedRealmIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error %s retrieving internal registered identity %+v using  %+v", err, identity.Identity, registeredIdentityClient)
 	}
-	if internalIdentityAuthenticationContext.RealmID != realm.ID || internalIdentityAuthenticationContext.RealmName != realm.Name || internalIdentityAuthenticationContext.Active != true {
+	if internalIdentityAuthenticationContext.RealmID != realm.ID || internalIdentityAuthenticationContext.RealmName != realm.Domain || internalIdentityAuthenticationContext.Active != true {
 		t.Fatalf("expected registered identity %+v to be an active member of realm %+v , got  %+v", identity.Identity, realm, internalIdentityAuthenticationContext)
 	}
 }
@@ -396,9 +396,9 @@ func TestInternalLDAPCacheCRUD(t *testing.T) {
 		RdnAttributeName: "cn",
 		Classes:          []string{"test", "of", "classes"},
 		Attributes: map[string][]string{
-			"cn":       []string{"testuser"},
-			"multi":    []string{"multiple", "values"},
-			"editable": []string{"this is editable"},
+			"cn":       {"testuser"},
+			"multi":    {"multiple", "values"},
+			"editable": {"this is editable"},
 		},
 		ReadOnlyAttributes: []string{"multi"},
 		Groups:             []string{"group1", "group2"},
@@ -1652,7 +1652,7 @@ func TestGroupRoleMappingCRD(t *testing.T) {
 		GroupID:   group.ID,
 		RoleMapping: RoleMapping{
 			ClientRoles: map[string][]Role{
-				application.ID: []Role{
+				application.ID: {
 					*realmApplicationRole,
 				},
 			},

--- a/request/interceptors.go
+++ b/request/interceptors.go
@@ -26,7 +26,11 @@ func LoggingInterceptor(l logging.Logger) Interceptor {
 	return InterceptorFunc(func(c Requester, r *http.Request) (*http.Response, error) {
 		startTime := time.Now()
 		resp, err := c.Do(r)
-		l.Debugf("%s request to %s at %s took %s", r.Method, r.URL, r.Header.Get("Date"), time.Now().Sub(startTime))
+		at := r.Header.Get("Date")
+		if at == "" {
+			at = startTime.String()
+		}
+		l.Debugf("%s request to %s at %s took %s", r.Method, r.URL, at, time.Now().Sub(startTime))
 		return resp, err
 	})
 }

--- a/request/interceptors.go
+++ b/request/interceptors.go
@@ -1,0 +1,29 @@
+package request
+
+import (
+	"net/http"
+
+	"github.com/tozny/utils-go/logging"
+	"golang.org/x/oauth2"
+)
+
+// ApplyTokenInterceptor adds an Authorization token from an oauth2 source to a
+// request as part of an interceptor.
+func ApplyTokenInterceptor(s oauth2.TokenSource) Interceptor {
+	return InterceptorFunc(func(c Requester, r *http.Request) (*http.Response, error) {
+		token, err := s.Token()
+		if err != nil {
+			return nil, err
+		}
+		token.SetAuthHeader(r)
+		return c.Do(r)
+	})
+}
+
+// LoggingInterceptor logs out request details when a logger in debug mode is supplied
+func LoggingInterceptor(l logging.Logger) Interceptor {
+	return InterceptorFunc(func(c Requester, r *http.Request) (*http.Response, error) {
+		l.Debugf("Making request to %s", r.URL)
+		return c.Do(r)
+	})
+}

--- a/request/interceptors.go
+++ b/request/interceptors.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/tozny/utils-go/logging"
 	"golang.org/x/oauth2"
@@ -23,7 +24,9 @@ func ApplyTokenInterceptor(s oauth2.TokenSource) Interceptor {
 // LoggingInterceptor logs out request details when a logger in debug mode is supplied
 func LoggingInterceptor(l logging.Logger) Interceptor {
 	return InterceptorFunc(func(c Requester, r *http.Request) (*http.Response, error) {
-		l.Debugf("Making request to %s", r.URL)
-		return c.Do(r)
+		startTime := time.Now()
+		resp, err := c.Do(r)
+		l.Debugf("%s request to %s at %s took %s", r.Method, r.URL, r.Header.Get("Date"), time.Now().Sub(startTime))
+		return resp, err
 	})
 }

--- a/request/request.go
+++ b/request/request.go
@@ -1,0 +1,43 @@
+package request
+
+import "net/http"
+
+// Requester is a partial interface which allows decoration of the http Client
+type Requester interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// RequesterFunc is a function with acts as a Requester
+type RequesterFunc func(*http.Request) (*http.Response, error)
+
+// Do calls f(r)
+func (f RequesterFunc) Do(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+// Interceptor is a function which decorates a Requester
+//
+// The interceptor can determine whether to pass the request down the line using
+// the Do method, or perform some kind of operation on it, before or after it is
+// sent. I could even short circuit the req, sending back a valid http Response,
+// never calling the Do method on the next Requester.
+type Interceptor func(Requester) Requester
+
+// InterceptorFunc is an adapter to allow the use of ordinary functions as an
+// Interceptor. If f is a function with the appropriate signature, InterceptorFunc(f)
+// is an Interceptor that calls f.
+func InterceptorFunc(f func(Requester, *http.Request) (*http.Response, error)) Interceptor {
+	return func(c Requester) Requester {
+		return RequesterFunc(func(r *http.Request) (*http.Response, error) {
+			return f(c, r)
+		})
+	}
+}
+
+// ApplyInterceptors decorates a Requester with all passed Interceptors.
+func ApplyInterceptors(requester Requester, interceptors ...Interceptor) Requester {
+	for _, decorator := range interceptors {
+		requester = decorator(requester)
+	}
+	return requester
+}

--- a/request/request.go
+++ b/request/request.go
@@ -19,7 +19,7 @@ func (f RequesterFunc) Do(r *http.Request) (*http.Response, error) {
 //
 // The interceptor can determine whether to pass the request down the line using
 // the Do method, or perform some kind of operation on it, before or after it is
-// sent. I could even short circuit the req, sending back a valid http Response,
+// sent. One could even short circuit the req, sending back a valid http Response,
 // never calling the Do method on the next Requester.
 type Interceptor func(Requester) Requester
 

--- a/storageClient/storageClient.go
+++ b/storageClient/storageClient.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tozny/e3db-clients-go/authClient"
 	"github.com/tozny/e3db-clients-go/clientServiceClient"
+	"github.com/tozny/e3db-clients-go/request"
 
 	"github.com/google/uuid"
 	e3dbClients "github.com/tozny/e3db-clients-go"
@@ -37,16 +38,17 @@ type StorageClient struct {
 	Host           string // host will generally need to be cyclops service to get the X-Tozny-Auth header
 	httpClient     *http.Client
 	*authClient.E3dbAuthClient
+	requester request.Requester
 }
 
 func (c *StorageClient) WriteNote(ctx context.Context, params Note) (*Note, error) {
 	var result *Note
 	path := c.Host + storageServiceBasePath + "/notes"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 
@@ -55,11 +57,11 @@ func (c *StorageClient) WriteNote(ctx context.Context, params Note) (*Note, erro
 func (c *StorageClient) CreateGroup(ctx context.Context, params CreateGroupRequest) (*Group, error) {
 	var result *Group
 	path := c.Host + storageServiceBasePath + "/groups"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 
@@ -68,23 +70,23 @@ func (c *StorageClient) CreateGroup(ctx context.Context, params CreateGroupReque
 func (c *StorageClient) DescribeGroup(ctx context.Context, params DescribeGroupRequest) (*Group, error) {
 	var result *Group
 	path := c.Host + storageServiceBasePath + "/groups/" + params.GroupID.String()
-	request, err := e3dbClients.CreateRequest("GET", path, params)
+	req, err := e3dbClients.CreateRequest("GET", path, params)
 	if err != nil {
 		return result, err
 	}
 
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 
 // DeleteGroup deletes a specified group, returning an error (if any).
 func (c *StorageClient) DeleteGroup(ctx context.Context, params DeleteGroupRequest) error {
 	path := c.Host + storageServiceBasePath + "/groups/" + params.GroupID.String()
-	request, err := e3dbClients.CreateRequest("DELETE", path, params)
+	req, err := e3dbClients.CreateRequest("DELETE", path, params)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 	return err
 }
 
@@ -92,11 +94,11 @@ func (c *StorageClient) DeleteGroup(ctx context.Context, params DeleteGroupReque
 func (c *StorageClient) ListGroups(ctx context.Context, params ListGroupsRequest) (*ListGroupsResponse, error) {
 	var result *ListGroupsResponse
 	path := c.Host + storageServiceBasePath + "/groups"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return result, err
 	}
-	urlParams := request.URL.Query()
+	urlParams := req.URL.Query()
 	urlParams.Set("nextToken", strconv.Itoa(int(params.NextToken)))
 	urlParams.Set("max", strconv.Itoa(int(params.Max)))
 	if params.ClientID != uuid.Nil {
@@ -105,33 +107,33 @@ func (c *StorageClient) ListGroups(ctx context.Context, params ListGroupsRequest
 	for _, groupName := range params.GroupNames {
 		urlParams.Add("group_names", groupName)
 	}
-	request.URL.RawQuery = urlParams.Encode()
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	req.URL.RawQuery = urlParams.Encode()
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 
-// AddGroupMembers Adds Clients to a group and returns the succesfuly added clients (if any).
+// AddGroupMembers Adds Clients to a group and returns the successfully added clients (if any).
 func (c *StorageClient) AddGroupMembers(ctx context.Context, params AddGroupMembersRequest) (*[]GroupMember, error) {
 	var result *[]GroupMember
 	path := c.Host + storageServiceBasePath + "/groups/" + params.GroupID.String() + "/members"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
 
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 
 // DeleteGroupMembers removed clients form a group and returns success.
 func (c *StorageClient) DeleteGroupMembers(ctx context.Context, params DeleteGroupMembersRequest) error {
 	path := c.Host + storageServiceBasePath + "/groups/" + params.GroupID.String() + "/members"
-	request, err := e3dbClients.CreateRequest("DELETE", path, params)
+	req, err := e3dbClients.CreateRequest("DELETE", path, params)
 	if err != nil {
 		return err
 	}
 
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 	return err
 }
 
@@ -149,11 +151,11 @@ func (c *StorageClient) ListGroupMembers(ctx context.Context, params ListGroupMe
 func (c *StorageClient) UpsertNoteByIDString(ctx context.Context, params Note) (*Note, error) {
 	var result *Note
 	path := c.Host + storageServiceBasePath + "/notes"
-	request, err := e3dbClients.CreateRequest("PUT", path, params)
+	req, err := e3dbClients.CreateRequest("PUT", path, params)
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 
@@ -214,13 +216,13 @@ func (c *StorageClient) EncryptMembershipKeyForGroupMember(ctx context.Context, 
 func (c *StorageClient) ReadNote(ctx context.Context, noteID string, eacpParams map[string]string) (*Note, error) {
 	var result *Note
 	path := c.Host + storageServiceBasePath + "/notes"
-	request, err := e3dbClients.CreateRequest("GET", path, nil)
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return result, err
 	}
 	// Set appropriate request query params & headers for satisfying
 	// a note's required EACPs
-	urlParams := request.URL.Query()
+	urlParams := req.URL.Query()
 	if eacpParams != nil {
 		for key, val := range eacpParams {
 			var isHeaderEACP bool
@@ -236,22 +238,22 @@ func (c *StorageClient) ReadNote(ctx context.Context, noteID string, eacpParams 
 		}
 	}
 	urlParams.Set("note_id", noteID)
-	request.URL.RawQuery = urlParams.Encode()
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	req.URL.RawQuery = urlParams.Encode()
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 
 func (c *StorageClient) Challenge(ctx context.Context, noteID string, params ChallengeRequest) (ChallengeResponse, error) {
 	var challenges ChallengeResponse
 	path := c.Host + storageServiceBasePath + "/notes/challenge"
-	request, err := e3dbClients.CreateRequest("PATCH", path, params)
+	req, err := e3dbClients.CreateRequest("PATCH", path, params)
 	if err != nil {
 		return challenges, err
 	}
-	urlParams := request.URL.Query()
+	urlParams := req.URL.Query()
 	urlParams.Set("note_id", noteID)
-	request.URL.RawQuery = urlParams.Encode()
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &challenges)
+	req.URL.RawQuery = urlParams.Encode()
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &challenges)
 	return challenges, err
 }
 
@@ -260,70 +262,70 @@ func (c *StorageClient) Challenge(ctx context.Context, noteID string, params Cha
 func (c *StorageClient) ProxyChallengeByName(ctx context.Context, headers http.Header, noteName string, params ChallengeRequest) (ChallengeResponse, error) {
 	var challenges ChallengeResponse
 	path := c.Host + storageServiceBasePath + "/notes/challenge"
-	request, err := e3dbClients.CreateRequest("PATCH", path, params)
+	req, err := e3dbClients.CreateRequest("PATCH", path, params)
 	if err != nil {
 		return challenges, err
 	}
-	urlParams := request.URL.Query()
+	urlParams := req.URL.Query()
 	urlParams.Set("id_string", noteName)
-	request.URL.RawQuery = urlParams.Encode()
-	err = e3dbClients.MakeProxiedSignedCall(ctx, headers, request, &challenges)
+	req.URL.RawQuery = urlParams.Encode()
+	err = e3dbClients.MakeProxiedSignedCall(ctx, c.requester, headers, req, &challenges)
 	return challenges, err
 }
 
 func (c *StorageClient) Prime(ctx context.Context, noteID string, body PrimeRequestBody) (PrimeResponseBody, error) {
 	path := c.Host + storageServiceBasePath + "/notes/prime"
-	request, err := e3dbClients.CreateRequest("PATCH", path, body)
+	req, err := e3dbClients.CreateRequest("PATCH", path, body)
 	var primedResponse PrimeResponseBody
 	if err != nil {
 		return primedResponse, err
 	}
-	urlParams := request.URL.Query()
+	urlParams := req.URL.Query()
 	urlParams.Set("note_id", noteID)
-	request.URL.RawQuery = urlParams.Encode()
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &primedResponse)
+	req.URL.RawQuery = urlParams.Encode()
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &primedResponse)
 	return primedResponse, err
 }
 
 func (c *StorageClient) BulkDeleteByClient(ctx context.Context, clientID uuid.UUID, limit int) (BulkDeleteResponse, error) {
 	path := c.Host + "/internal" + storageServiceBasePath + "/notes/bulk/" + clientID.String()
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	var resp BulkDeleteResponse
 	if err != nil {
 		return resp, err
 	}
-	urlParams := request.URL.Query()
+	urlParams := req.URL.Query()
 	if limit != 0 {
 		urlParams.Set("limit", strconv.Itoa(limit))
 	}
-	request.URL.RawQuery = urlParams.Encode()
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &resp)
+	req.URL.RawQuery = urlParams.Encode()
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &resp)
 	return resp, err
 }
 
 func (c *StorageClient) InternalDeleteNoteByID(ctx context.Context, noteID uuid.UUID) error {
 	path := c.Host + "/internal" + storageServiceBasePath + "/notes"
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	urlParams := request.URL.Query()
+	urlParams := req.URL.Query()
 	urlParams.Set("note_id", noteID.String())
-	request.URL.RawQuery = urlParams.Encode()
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	req.URL.RawQuery = urlParams.Encode()
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 	return err
 }
 
 func (c *StorageClient) InternalDeleteNoteByName(ctx context.Context, noteName string) error {
 	path := c.Host + "/internal" + storageServiceBasePath + "/notes"
-	request, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	urlParams := request.URL.Query()
+	urlParams := req.URL.Query()
 	urlParams.Set("id_string", noteName)
-	request.URL.RawQuery = urlParams.Encode()
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, nil)
+	req.URL.RawQuery = urlParams.Encode()
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 	return err
 }
 
@@ -333,11 +335,11 @@ func (c *StorageClient) InternalDeleteNoteByName(ctx context.Context, noteName s
 func (c *StorageClient) InternalSearchBySharingGroup(ctx context.Context, params InternalSearchBySharingTupleRequest) (*InternalSearchBySharingTupleResponse, error) {
 	var result *InternalSearchBySharingTupleResponse
 	path := c.Host + "/internal" + storageServiceBasePath + "/search/sharing-group"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 
@@ -345,11 +347,11 @@ func (c *StorageClient) InternalSearchBySharingGroup(ctx context.Context, params
 func (c *StorageClient) OutgoingShares(ctx context.Context, params OutgoingShareRequest) (*OutgoingShareResponse, error) {
 	var result *OutgoingShareResponse
 	path := c.Host + storageServiceBasePath + "/share/outgoing"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 
@@ -357,11 +359,11 @@ func (c *StorageClient) OutgoingShares(ctx context.Context, params OutgoingShare
 func (c *StorageClient) IncomingShares(ctx context.Context, params SearchIncomingSharesRequest) (*SearchIncomingSharesResponse, error) {
 	var result *SearchIncomingSharesResponse
 	path := c.Host + storageServiceBasePath + "/share/incoming"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 
@@ -369,11 +371,11 @@ func (c *StorageClient) IncomingShares(ctx context.Context, params SearchIncomin
 func (c *StorageClient) ProxiedAuthorization(ctx context.Context, params SearchAuthorizationsProxiedRequest) (*SearchAuthorizationsProxiedResponse, error) {
 	var result *SearchAuthorizationsProxiedResponse
 	path := c.Host + storageServiceBasePath + "/authorizer/outgoing"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 
@@ -381,44 +383,44 @@ func (c *StorageClient) ProxiedAuthorization(ctx context.Context, params SearchA
 func (c *StorageClient) GrantedAuthorizations(ctx context.Context, params SearchAuthorizedGrantedRequest) (*SearchAuthorizedGrantedResponse, error) {
 	var result *SearchAuthorizedGrantedResponse
 	path := c.Host + storageServiceBasePath + "/authorizer/incoming"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 
 func (c *StorageClient) WriteRecord(ctx context.Context, params Record) (*Record, error) {
 	var result *Record
 	path := c.Host + storageServiceBasePath + "/records"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, &result)
 	return result, err
 }
 
 func (c *StorageClient) WriteFile(ctx context.Context, params Record) (*PendingFileResponse, error) {
 	var result *PendingFileResponse
 	path := c.Host + storageServiceBasePath + "/files"
-	request, err := e3dbClients.CreateRequest("POST", path, params)
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, &result)
 	return result, err
 }
 
 func (c *StorageClient) FileCommit(ctx context.Context, pendingFileID uuid.UUID) (*Record, error) {
 	var result *Record
 	path := c.Host + storageServiceBasePath + "/files/" + pendingFileID.String()
-	request, err := e3dbClients.CreateRequest("PATCH", path, nil)
+	req, err := e3dbClients.CreateRequest("PATCH", path, nil)
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeE3DBServiceCall(c.E3dbAuthClient, ctx, request, &result)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, &result)
 	return result, err
 }
 
@@ -432,5 +434,6 @@ func New(config e3dbClients.ClientConfig) StorageClient {
 		ClientID:       config.ClientID,
 		httpClient:     &http.Client{},
 		E3dbAuthClient: &authService,
+		requester:      request.ApplyInterceptors(&http.Client{}, config.Interceptors...),
 	}
 }

--- a/storageClient/storageClient.go
+++ b/storageClient/storageClient.go
@@ -137,7 +137,7 @@ func (c *StorageClient) DeleteGroupMembers(ctx context.Context, params DeleteGro
 	return err
 }
 
-// ListGroupMembers returns the group members and capabilites based on the groupID
+// ListGroupMembers returns the group members and capabilities based on the groupID
 func (c *StorageClient) ListGroupMembers(ctx context.Context, params ListGroupMembersRequest) (*[]GroupMember, error) {
 	var result *[]GroupMember
 	path := c.Host + storageServiceBasePath + "/groups/" + params.GroupID.String() + "/members"
@@ -145,7 +145,7 @@ func (c *StorageClient) ListGroupMembers(ctx context.Context, params ListGroupMe
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, request, c.SigningKeys, c.ClientID, &result)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, request, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
 func (c *StorageClient) UpsertNoteByIDString(ctx context.Context, params Note) (*Note, error) {

--- a/storageClient/storageClient_test.go
+++ b/storageClient/storageClient_test.go
@@ -473,7 +473,7 @@ func TestListGroupsWithQueenClientAllAccountReturnsSuccess(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed generating encrypted group key  %s", err)
 	}
-	// Create Another Accouunt under the queen client to list groups, Each create a group
+	// Create Another Account under the queen client to list groups, Each create a group
 	group := storageClientV2.CreateGroupRequest{
 		Name:              "TestGroup1" + uuid.New().String(),
 		PublicKey:         encryptionKeyPair.Public.Material,
@@ -909,7 +909,7 @@ func TestCreateGroupMembershipKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create membership key \n response %+v \n error %+v", membershipKeyResponse, err)
 	}
-	// Verify that the group membership key for the client matches the output for the group raw privat key above
+	// Verify that the group membership key for the client matches the output for the group raw private key above
 	rawEncryptionKey, err := e3dbClients.DecodeSymmetricKey(groupMemberToAdd.EncryptionKeys.Private.Material)
 	if err != nil {
 		t.Fatalf("Client to add to group Private key was not decoded correctly \n Client: %+v, err: %+v ", groupMemberToAdd, err)
@@ -1084,7 +1084,7 @@ func TestAddBulkGroupMemberWithValidInputReturnsSuccess(t *testing.T) {
 	}
 	membershipKeyResponse2, err := queenClient.CreateGroupMembershipKey(testCtx, membershipKeyRequest2)
 	if err != nil {
-		t.Fatalf("Failed to create membership key \n response %+v \n error %+v", membershipKeyResponse, err)
+		t.Fatalf("Failed to create membership key \n response %+v \n error %+v", membershipKeyResponse2, err)
 	}
 	// Add clients  to group
 	groupMemberCapabilities := []string{storageClientV2.ShareContentGroupCapability, storageClientV2.ReadContentGroupCapability}

--- a/tsv1.go
+++ b/tsv1.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	HashingAlgorithim    = "BLAKE2B"
+	HashingAlgorithm     = "BLAKE2B"
 	SignatureType        = "ED25519"
-	AuthenticationMethod = "TSV1-" + SignatureType + "-" + HashingAlgorithim // TSV1-ED25519-BLAKE2B
+	AuthenticationMethod = "TSV1-" + SignatureType + "-" + HashingAlgorithm // TSV1-ED25519-BLAKE2B
 	PublicKeyBytes       = 32
 	PrivateKeyBytes      = 64
 	AuthorizationHeader  = "Authorization"


### PR DESCRIPTION
This updates our client go library, adding the ability to use interceptors in our clients. This is a concept seen in many popular request libraries (axios in Javascript, okhttp in Java, etc.). 

I'm not super happy with the naming, esepically but ran with it to avoid additional refactor time. The PR itself is _very_ formulaic, so reading through should be pretty quick.

The Auth http client has been swapped to use an interceptor instead of the client from the oauth2 package -- under the hood it uses the same methods, but made the interceptor logic more consistent.

Fixed up some reported lint errors while in files, so you see minor tweaks, spelling updates, etc.

Tests are all passing against platform after some rebasing to catch new code from yesterday.