### PR TITLE
fixing tests for new default application roles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,11 @@ version:
 
 it : lint
 	go test -count=1 -v -cover --race ./... -run=TestGetToznyHostedBrokerInfo
+
+# Run all Identity Integration tests
+test-identity:
+	go test  -v  identityClient/identityClient_test.go identityClient/identityClient.go identityClient/api.go 
+
+# Run all Storage Integration tests
+test-storage:
+	go test -count=1 -v storageClient/storageClient_test.go

--- a/identityClient/api.go
+++ b/identityClient/api.go
@@ -31,6 +31,7 @@ const (
 	BasicSAMLAttributeNameFormat                            = "Basic"
 	UnspecifiedSAMLAttributeNameFormat                      = "Unspecified"
 	URIReferenceSAMLAttributeNameFormat                     = "URI Reference"
+	DefaultUMAProtectionApplicationRole                     = "uma_protection"
 )
 
 var (

--- a/storageClient/storageClient_test.go
+++ b/storageClient/storageClient_test.go
@@ -892,7 +892,6 @@ func TestCreateGroupMembershipKey(t *testing.T) {
 		EncryptedGroupKey: eak,
 	}
 	response, err := queenClient.CreateGroup(testCtx, newGroup)
-	t.Logf("%+v", response)
 	if err != nil {
 		t.Fatalf("Failed to create group \n Group( %+v) \n error %+v", newGroup, err)
 	}


### PR DESCRIPTION
During deployment we found tests for identity that required a bit of fixing to pass with our new application roles! Added new makefile rules and deleted a miscellaneous log line in storage