### PR TITLE
Add identity and storage methods to support sdk-login

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,32 +59,32 @@ From a go package
 package main
 
 import (
-    "github.com/tozny/e3db-clients-go"
-    "github.com/tozny/e3db-clients-go/hookClient"
-    "context"
+	"context"
+	"github.com/tozny/e3db-clients-go"
+	"github.com/tozny/e3db-clients-go/hookClient"
 )
 
 func main() {
-    config := e3dbClients.ClientConfig{
-        APIKey:    "E3DBAPIKEYID",
-        APISecret: "E3DBAPIKEYSECRET",
-        Host:      "https://api.e3db.com",
-    }
-    client := hookClient.New(ValidClientConfig, config.Host)
-    createHookRequest := hookClient.CreateHookRequest{
-        WebhookURL: "https://en8781lpip6xb.x.pipedream.net/",
-        Triggers: []hookClient.HookTrigger{
-            hookClient.HookTrigger{
-                Enabled:  true,
-                APIEvent: "authorizer_added",
-            },
-        },
-    }
-    ctx := context.TODO()
-    response, err := client.CreateHook(ctx, createHookRequest)
-    if err != nil {
-        t.Errorf("Error %s calling CreateHook with %+v\n", err, createHookRequest)
-    }
+	config := e3dbClients.ClientConfig{
+		APIKey:    "E3DBAPIKEYID",
+		APISecret: "E3DBAPIKEYSECRET",
+		Host:      "https://api.e3db.com",
+	}
+	client := hookClient.New(ValidClientConfig, config.Host)
+	createHookRequest := hookClient.CreateHookRequest{
+		WebhookURL: "https://en8781lpip6xb.x.pipedream.net/",
+		Triggers: []hookClient.HookTrigger{
+			hookClient.HookTrigger{
+				Enabled:  true,
+				APIEvent: "authorizer_added",
+			},
+		},
+	}
+	ctx := context.TODO()
+	response, err := client.CreateHook(ctx, createHookRequest)
+	if err != nil {
+		t.Errorf("Error %s calling CreateHook with %+v\n", err, createHookRequest)
+	}
 }
 ```
 

--- a/authClient/api.go
+++ b/authClient/api.go
@@ -2,12 +2,12 @@ package authClient
 
 // ValidateTokenRequest represents a valid request to the auth service's /validate endpoint.
 type ValidateTokenRequest struct {
-    Token    string `json:"token"`    //The token to validate
-    Internal bool   `json:"internal"` //Whether this token belongs to an internal client
+	Token    string `json:"token"`    // The token to validate
+	Internal bool   `json:"internal"` // Whether this token belongs to an internal client
 }
 
-// ValidateTokenRequest represents a response to calling auth service's /validate endpoint.
+// ValidateTokenResponse represents a response to calling auth service's /validate endpoint.
 type ValidateTokenResponse struct {
-    ClientId string `json:"client_id"` //The client associated with this token
-    Valid    bool   `json:"valid"`     //Whether the token was valid
+	ClientId string `json:"client_id"` // The client associated with this token
+	Valid    bool   `json:"valid"`     // Whether the token was valid
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/tozny/e3db-clients-go
 
 require (
 	github.com/google/uuid v1.1.0
+	github.com/gorilla/schema v1.2.0
 	github.com/tozny/utils-go v0.0.35
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/uuid v1.1.0 h1:Jf4mxPC/ziBnoPIdpQdPJ9OeiomAUHLvxmPRSPH9m4s=
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=
+github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/identityClient/api.go
+++ b/identityClient/api.go
@@ -2,6 +2,7 @@ package identityClient
 
 import (
 	"github.com/google/uuid"
+	"time"
 )
 
 const (
@@ -119,6 +120,70 @@ type RegisterIdentityRequest struct {
 type RegisterIdentityResponse struct {
 	Identity                   Identity  `json:"identity"`
 	RealmBrokerIdentityToznyID uuid.UUID `json:"realm_broker_identity_tozny_id,omitempty"`
+}
+
+// IdentityLoginRequest wraps parameters needed to initiate an identity login session.
+type IdentityLoginRequest struct {
+	Username    string `json:"username"`
+	RedirectURL string `json:"redirect_url"`
+	RealmName   string `json:"realm_name"`
+	AppName     string `json:"app_name"`
+	LoginStyle  string `json:"login_style"`
+}
+
+// InitialLoginResponse is returned by the login endpoint on success
+type InitialLoginResponse struct {
+	Nonce         string `json:"nonce" schema:"nonce"`
+	ClientID      string `json:"client_id" schema:"client_id"`
+	ResponseType  string `json:"response_type" schema:"response_type"`
+	Scope         string `json:"scope" schema:"scope"`
+	RedirectURI   string `json:"redirect_uri" schema:"redirect_uri"`
+	ResponseMode  string `json:"response_mode" schema:"response_mode"`
+	State         string `json:"state" schema:"state"`
+	Username      string `json:"username" schema:"username"`
+	Target        string `json:"target" schema:"target"`
+	AuthSessionID string `json:"auth_session_id" schema:"auth_session_id"`
+	Federated     bool   `json:"federated" schema:"federated"`
+}
+
+// IdentitySessionRequestResponse is returned by the IdentitySesssionRequest. It contains data related to what additional
+// actions are needed to create a session and how to create the session
+type IdentitySessionRequestResponse struct {
+	LoginAction     bool                   `json:"login_action"`
+	LoginActionType string                 `json:"type"`
+	ActionURL       string                 `json:"action_url"`
+	Fields          map[string]string      `json:"fields"`
+	Context         map[string]string      `json:"context"`
+	ContentType     string                 `json:"content_type"`
+	Message         SessionResponseMessage `json:"message"`
+}
+
+// SessionResponseMessage provides information reagarding the error status of login actions
+// IsError is the most reliable source of information if the login action was successful or not
+type SessionResponseMessage struct {
+	Summary     string `json:"summary"`
+	MessageType string `json:"type"`
+	IsError     bool   `json:"error"`
+	Warning     bool   `json:"warning"`
+	Success     bool   `json:"success"`
+}
+
+// IdentityLoginRedirectRequest wraps parameters need to complete an identity login
+type IdentityLoginRedirectRequest struct {
+	RealmName     string `json:"realm_name"`
+	SessionCode   string `json:"session_code"`
+	Execution     string `json:"execution"`
+	TabID         string `json:"tab_id"`
+	ClientID      string `json:"client_id"`
+	AuthSessionId string `json:"auth_session_id"`
+}
+
+// IdentityLoginRedirectResponse is returned by the IdentityLoginRedirect and contains access tokens for
+// retrieving clients and sessions
+type IdentityLoginRedirectResponse struct {
+	AccessToken string    `json:"access_token"`
+	TokenType   string    `json:"token_type"`
+	Expiry      time.Time `json:"expiry"`
 }
 
 // IdentityLoginResponse wraps an extended OpenID v1.0 compatible Token Response

--- a/identityClient/identityClient_test.go
+++ b/identityClient/identityClient_test.go
@@ -1624,7 +1624,7 @@ func TestDescribeApplicationRoleReturnsCreatedApplicationRole(t *testing.T) {
 		t.Errorf("expected result role name to be '%s', was '%s'", roleName, actual.Name)
 	}
 
-	roleDescription := (roleName + " description")
+	roleDescription := roleName + " description"
 
 	if actual.Description != roleDescription {
 		t.Errorf("expected result role description to be '%s', was '%s'", roleDescription, actual.Description)
@@ -1677,7 +1677,7 @@ func TestListApplicationRoleReturnsCreatedApplicationRoles(t *testing.T) {
 	if len(actual) != expectedNumberOfAplicationRoles {
 		t.Errorf("expected %d number of realm roles, recieved %+v", expectedNumberOfAplicationRoles, actual)
 	}
-	roleDescription := (roleName + " description")
+	roleDescription := roleName + " description"
 	var found bool
 	for _, role := range actual {
 		if role.Name == roleName {
@@ -2996,7 +2996,7 @@ func TestSearchingIdentitiesOnlyReturnsIdentifiersForValidClientIDs(t *testing.T
 	anonConfig := e3dbClients.ClientConfig{
 		Host: toznyCyclopsHost,
 	}
-	anonClient :=New(anonConfig)
+	anonClient := New(anonConfig)
 	registerResponse, err := anonClient.RegisterIdentity(testContext, registerParams)
 	if err != nil {
 		t.Fatalf("Error %s registering identity using %+v %+v", err, anonClient, registerParams)
@@ -3070,7 +3070,7 @@ func TestSearchingIdentitiesWithClientIDsValidRealmReturnsSuccess(t *testing.T) 
 		RealmName:              realm.Name,
 		Identity: Identity{
 			Name:        identityName,
-			PublicKeys:  map[string]string{e3dbClients.DefaultEncryptionKeyType:  encryptionKeyPair.Public.Material},
+			PublicKeys:  map[string]string{e3dbClients.DefaultEncryptionKeyType: encryptionKeyPair.Public.Material},
 			SigningKeys: map[string]string{signingKeys.Public.Type: signingKeys.Public.Material},
 			FirstName:   identityFirstName,
 			LastName:    identityLastName,

--- a/pdsClient/pdsClient.go
+++ b/pdsClient/pdsClient.go
@@ -437,7 +437,7 @@ func (c *E3dbPDSClient) DecryptRecord(ctx context.Context, record Record) (Recor
 		return record, err
 	}
 	// Return the decrypted record
-	record.Data = *decrypted
+	record.Data = decrypted
 	return record, err
 }
 
@@ -474,7 +474,7 @@ func (c *E3dbPDSClient) DecryptGroupRecordWithGroupEncryptedAccessKey(ctx contex
 		return record, err
 	}
 	// Return the decrypted record
-	record.Data = *decrypted
+	record.Data = decrypted
 	return record, err
 }
 

--- a/secretstream/secretstream_new.go
+++ b/secretstream/secretstream_new.go
@@ -1,5 +1,5 @@
 // The open ticket to make this part of the Golang core:
-// https://go-review.googlesource.com/c/crypto/+/288969 
+// https://go-review.googlesource.com/c/crypto/+/288969
 
 // Copyright 2020 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/storageClient/storageClient_test.go
+++ b/storageClient/storageClient_test.go
@@ -734,7 +734,7 @@ func TestListGroupsWithQueenClientForClientWithGroupsReturnsSuccess(t *testing.T
 		t.Fatalf("Failed to list Group: Response( %+v) \n error %+v", responseList, err)
 	}
 	for _, groupID := range []uuid.UUID{groupCreatedID1, groupCreatedID2} {
-		var found bool = false
+		var found = false
 		for _, group := range responseList.Groups {
 			if group.GroupID == groupID {
 				found = true
@@ -804,7 +804,7 @@ func TestListGroupsWithQueenClientAllAccountReturnsSuccess(t *testing.T) {
 		t.Fatalf("Failed to list Group: Response( %+v) \n error %+v", responseList, err)
 	}
 	for _, groupID := range []uuid.UUID{groupCreatedID1, groupCreatedID2} {
-		var found bool = false
+		var found = false
 		for _, group := range responseList.Groups {
 			if group.GroupID == groupID {
 				found = true
@@ -864,7 +864,7 @@ func TestListGroupsWithClientForClientWithGroupsReturnsSuccess(t *testing.T) {
 		t.Fatalf("Group LIST: Group was Not Found: %+v Error: %+v ", responseList, err)
 	}
 	for _, groupID := range []uuid.UUID{groupCreatedID1} {
-		var found bool = false
+		var found = false
 		for _, group := range responseList.Groups {
 			if group.GroupID == groupID {
 				found = true
@@ -992,7 +992,7 @@ func TestListGroupsWithQueenClientForClientWithGroupsFilteredByGroupNameReturnsO
 		t.Fatalf("Failed to list Group: Response( %+v) \n error %+v", responseList, err)
 	}
 	for _, groupID := range []uuid.UUID{groupCreatedID1, groupCreatedID2} {
-		var found bool = false
+		var found = false
 		for _, group := range responseList.Groups {
 			if group.GroupID == groupID {
 				found = true
@@ -1132,7 +1132,7 @@ func TestListGroupsWithClientForClientWithGroupsFilteredByGroupNameReturnsAllGro
 		t.Fatalf("Group LIST: Group was Not Found: %+v Error: %+v ", responseList, err)
 	}
 	for _, groupID := range []uuid.UUID{groupCreatedID1, groupCreatedID2} {
-		var found bool = false
+		var found = false
 		for _, group := range responseList.Groups {
 			if group.GroupID == groupID {
 				found = true


### PR DESCRIPTION
- Adds identity flow methods
- Adds storage service methods for fetching notes by name
- Adds crypto methods for note reading and validation
- This does not currently have tests as the functionality to derive credential notes is in e3db-go (which will cause a circular dependency) we may want to shift that code here to allow for better testing