### PR TITLE
[WR-release] identityClient_test stability improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ it : lint
 
 # Run all Identity Integration tests
 test-identity:
-	go test  -v  identityClient/identityClient_test.go identityClient/identityClient.go identityClient/api.go 
+	go test -timeout 20m -v identityClient/identityClient_test.go identityClient/identityClient.go identityClient/api.go
 
 # Run Internal Identity Integration Tests
 test-intenal-identity:

--- a/identityClient/identityClient_test.go
+++ b/identityClient/identityClient_test.go
@@ -3,6 +3,7 @@ package identityClient
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"testing"
@@ -124,7 +125,10 @@ func registerIdentity(t *testing.T, identityServiceClient E3dbIdentityClient, re
 }
 
 func uniqueString(prefix string) string {
-	return fmt.Sprintf("%s%d", prefix, time.Now().Unix())
+	rand.Seed(time.Now().UnixNano())
+
+	return fmt.Sprintf("%s%d", prefix, rand.Int())
+}
 }
 
 func createRealm(t *testing.T, identityServiceClient E3dbIdentityClient) *Realm {
@@ -621,13 +625,9 @@ func TestApplicationCRD(t *testing.T) {
 	}
 
 	queenClientInfo.Host = e3dbIdentityHost
-
 	identityServiceClient := New(queenClientInfo)
-
-	realmName := fmt.Sprintf("TestApplicationCRD%d", time.Now().Unix())
-
+	realmName := uniqueString("TestApplicationCRD")
 	sovereignName := "Yassqueen"
-
 	params := CreateRealmRequest{
 		RealmName:     realmName,
 		SovereignName: sovereignName,
@@ -711,7 +711,6 @@ func TestApplicationCRD(t *testing.T) {
 
 func TestProviderCRD(t *testing.T) {
 	accountTag := uuid.New().String()
-
 	queenClientInfo, _, err := test.MakeE3DBAccount(t, &accountServiceClient, accountTag, e3dbAuthHost)
 
 	if err != nil {
@@ -719,13 +718,9 @@ func TestProviderCRD(t *testing.T) {
 	}
 
 	queenClientInfo.Host = e3dbIdentityHost
-
 	identityServiceClient := New(queenClientInfo)
-
-	realmName := fmt.Sprintf("TestProviderCRD%d", time.Now().Unix())
-
+	realmName := uniqueString("TestProviderCRD")
 	sovereignName := "Yassqueen"
-
 	params := CreateRealmRequest{
 		RealmName:     realmName,
 		SovereignName: sovereignName,
@@ -827,7 +822,6 @@ func TestProviderCRD(t *testing.T) {
 
 func TestProviderMapperCRD(t *testing.T) {
 	accountTag := uuid.New().String()
-
 	queenClientInfo, _, err := test.MakeE3DBAccount(t, &accountServiceClient, accountTag, e3dbAuthHost)
 
 	if err != nil {
@@ -835,13 +829,9 @@ func TestProviderMapperCRD(t *testing.T) {
 	}
 
 	queenClientInfo.Host = e3dbIdentityHost
-
 	identityServiceClient := New(queenClientInfo)
-
-	realmName := fmt.Sprintf("TestProviderMapperCRD%d", time.Now().Unix())
-
+	realmName := uniqueString("TestProviderMapperCRD")
 	sovereignName := "Yassqueen"
-
 	params := CreateRealmRequest{
 		RealmName:     realmName,
 		SovereignName: sovereignName,
@@ -1010,7 +1000,7 @@ func TestListIdentitiesPaginates(t *testing.T) {
 
 	// New Realm
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("TestListIdentities%d", time.Now().Unix())
+	realmName := uniqueString("TestListIdentities")
 	sovereignName := "Yassqueen"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -1111,7 +1101,7 @@ func TestListIdentitiesRespectsOffest(t *testing.T) {
 
 	// New Realm
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("TestListIdentities%d", time.Now().Unix())
+	realmName := uniqueString("TestListIdentities")
 	sovereignName := "Yassqueen"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -1190,7 +1180,7 @@ func TestIdentityDetails(t *testing.T) {
 
 	// New Realm
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("TestListIdentities%d", time.Now().Unix())
+	realmName := uniqueString("TestListIdentities")
 	sovereignName := "yassqueen"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -1956,7 +1946,7 @@ func TestRealmRoleCRD(t *testing.T) {
 	queenClientInfo.Host = e3dbIdentityHost
 	identityServiceClient := New(queenClientInfo)
 
-	realmName := fmt.Sprintf("TestRealmRoleCRD%d", time.Now().Unix())
+	realmName := uniqueString("TestRealmRoleCRD")
 	sovereignName := "Yassqueen"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2042,7 +2032,7 @@ func TestFetchApplicationSecret(t *testing.T) {
 	queenClientInfo.Host = e3dbIdentityHost
 	identityServiceClient := New(queenClientInfo)
 
-	realmName := fmt.Sprintf("TestFetchApplicationSecret%d", time.Now().Unix())
+	realmName := uniqueString("TestFetchApplicationSecret")
 	sovereignName := "Yassqueen"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2096,7 +2086,7 @@ func TestFetchApplicationSAMLSDescription(t *testing.T) {
 	queenClientInfo.Host = e3dbIdentityHost
 	identityServiceClient := New(queenClientInfo)
 
-	realmName := fmt.Sprintf("TestFetchApplicationSAMLSDescription%d", time.Now().Unix())
+	realmName := uniqueString("TestFetchApplicationSAMLSDescription")
 	sovereignName := "Yassqueen"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2161,7 +2151,7 @@ func TestApplicationMapperCRD(t *testing.T) {
 	queenClientInfo.Host = e3dbIdentityHost
 	identityServiceClient := New(queenClientInfo)
 	// Create realm
-	realmName := fmt.Sprintf("TestApplicationMapperCRD%d", time.Now().Unix())
+	realmName := uniqueString("TestApplicationMapperCRD")
 	sovereignName := "Yassqueen"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2266,7 +2256,7 @@ func TestSearchingIdentitiesWithEmailValidRealmReturnsSuccess(t *testing.T) {
 	}
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("TestSearchIdentities%d", time.Now().Unix())
+	realmName := uniqueString("TestSearchIdentities")
 	sovereignName := "QueenCoolName"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2345,7 +2335,7 @@ func TestSearchingIdentitiesWithEmailValidRealmInvalidIdentitiesReturnsSuccess(t
 	}
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("TestSearchIdentities%d", time.Now().Unix())
+	realmName := uniqueString("TestSearchIdentities")
 	sovereignName := "QueenCoolName"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2374,7 +2364,7 @@ func TestSearchingIdentitiesOnlyReturnsIdentifiersForValidEmails(t *testing.T) {
 	}
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("TestSearchIdentities%d", time.Now().Unix())
+	realmName := uniqueString("TestSearchIdentities")
 	sovereignName := "QueenCoolName"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2457,7 +2447,7 @@ func TestSearchingIdentitiesWithUsernameValidRealmReturnsSuccess(t *testing.T) {
 	}
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("TestSearchIdentities%d", time.Now().Unix())
+	realmName := uniqueString("TestSearchIdentities")
 	sovereignName := "QueenCoolName"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2537,7 +2527,7 @@ func TestSearchingIdentitiesWithUsernameValidRealmInvalidIdentitiesReturnsSucces
 	}
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("TestSearchIdentities%d", time.Now().Unix())
+	realmName := uniqueString("TestSearchIdentities")
 	sovereignName := "QueenCoolName"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2565,7 +2555,7 @@ func TestSearchingIdentitiesOnlyReturnsIdentifiersForValidUsernames(t *testing.T
 	}
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("TestSearchIdentities%d", time.Now().Unix())
+	realmName := uniqueString("TestSearchIdentities")
 	sovereignName := "QueenCoolName"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2649,7 +2639,7 @@ func TestGetPrivateRealmInfoReturnsSuccessForAuthorizedRealmIdentity(t *testing.
 	}
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("PrivatRealmInfo%d", time.Now().Unix())
+	realmName := uniqueString("PrivatRealmInfo")
 	sovereignName := "QueenCoolName"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2720,7 +2710,7 @@ func TestSearchingIdentitiesOnlyReturnsIdentifiersForValidClientIDs(t *testing.T
 	}
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("TestSearchIdentities%d", time.Now().Unix())
+	realmName := uniqueString("TestSearchIdentities")
 	sovereignName := "QueenCoolName"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2804,7 +2794,7 @@ func TestSearchingIdentitiesWithClientIDsValidRealmReturnsSuccess(t *testing.T) 
 	}
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("TestSearchIdentities%d", time.Now().Unix())
+	realmName := uniqueString("TestSearchIdentities")
 	sovereignName := "QueenCoolName"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2884,7 +2874,7 @@ func TestUpdateRealmSetting(t *testing.T) {
 	}
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("PrivatRealmInfo%d", time.Now().Unix())
+	realmName := uniqueString("PrivatRealmInfo")
 	sovereignName := "QueenCoolName"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -2949,7 +2939,7 @@ func TestUpdateRealmSettingwithNoUpdatedValues(t *testing.T) {
 	}
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
-	realmName := fmt.Sprintf("PrivatRealmInfo%d", time.Now().Unix())
+	realmName := uniqueString("PrivatRealmInfo")
 	sovereignName := "QueenCoolName"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -3013,8 +3003,7 @@ func TestRealmRoleCRUD(t *testing.T) {
 
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
-
-	realmName := fmt.Sprintf("TestRealmRoleCRUD%d", time.Now().Unix())
+	realmName := uniqueString("TestRealmRoleCRUD")
 	sovereignName := "Yassqueen"
 	params := CreateRealmRequest{
 		RealmName:     realmName,
@@ -3131,7 +3120,7 @@ func TestUpdateRole(t *testing.T) {
 	queenClientInfo.Host = toznyCyclopsHost
 	identityServiceClient := New(queenClientInfo)
 
-	realmName := fmt.Sprintf("TestRealmRoleCRUD%d", time.Now().Unix())
+	realmName := uniqueString("TestRealmRoleCRUD")
 	sovereignName := "Yassqueen"
 	params := CreateRealmRequest{
 		RealmName:     realmName,

--- a/identityClient/identityClient_test.go
+++ b/identityClient/identityClient_test.go
@@ -129,6 +129,23 @@ func uniqueString(prefix string) string {
 
 	return fmt.Sprintf("%s%d", prefix, rand.Int())
 }
+
+func createRealmWithParams(t *testing.T, identityServiceClient E3dbIdentityClient, params CreateRealmRequest) *Realm {
+	realm, err := identityServiceClient.CreateRealm(testContext, params)
+	if err == nil {
+		return realm
+	}
+
+	t.Log("=================================")
+	t.Log("FAILED to create realm, RE-TRY...")
+	t.Log("=================================")
+
+	realm, err = identityServiceClient.CreateRealm(testContext, params)
+	if err != nil {
+		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
+	}
+
+	return realm
 }
 
 func createRealm(t *testing.T, identityServiceClient E3dbIdentityClient) *Realm {
@@ -137,11 +154,8 @@ func createRealm(t *testing.T, identityServiceClient E3dbIdentityClient) *Realm 
 		RealmName:     unique,
 		SovereignName: "realmsovereign",
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
-	return realm
+
+	return createRealmWithParams(t, identityServiceClient, params)
 }
 
 func createRealmApplication(t *testing.T, identityServiceClient E3dbIdentityClient, realmName string) *Application {
@@ -340,10 +354,7 @@ func TestCreateRealmCreatesRealmWithUserDefinedName(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Errorf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	if realm.Name != realmName {
 		t.Errorf("expected realm name to be %+v , got %+v", realmName, realm)
@@ -364,10 +375,7 @@ func TestDescribeRealmReturnsDetailsOfCreatedRealm(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	describedRealm, err := identityServiceClient.DescribeRealm(testContext, realm.Name)
 	if err != nil {
@@ -392,10 +400,7 @@ func TestDeleteRealmDeletesCreatedRealm(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	describedRealm, err := identityServiceClient.DescribeRealm(testContext, realm.Name)
 	if err != nil {
@@ -433,10 +438,7 @@ func TestRegisterIdentityWithCreatedRealm(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	identityName := "Freud"
 	identityEmail := "freud@example.com"
@@ -493,10 +495,7 @@ func TestIdentityLoginWithRegisteredIdentity(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	identityName := "Freud"
 	signingKeys, err := e3dbClients.GenerateSigningKeys()
@@ -556,10 +555,7 @@ func TestRegisterRealmBrokerIdentityWithCreatedRealm(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	identityName := "Freud"
 	signingKeys, err := e3dbClients.GenerateSigningKeys()
@@ -632,13 +628,7 @@ func TestApplicationCRD(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
-
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 
 	autoGeneratedApplications, err := identityServiceClient.ListRealmApplications(testContext, realm.Name)
@@ -725,13 +715,7 @@ func TestProviderCRD(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
-
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 
 	autoGeneratedProviders, err := identityServiceClient.ListRealmProviders(testContext, realm.Name)
@@ -836,13 +820,7 @@ func TestProviderMapperCRD(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
-
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 
 	realmProviderCreateParams := CreateRealmProviderRequest{
@@ -1006,10 +984,7 @@ func TestListIdentitiesPaginates(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	// Register multiple identities
 	// These identities can use the same keys...
@@ -1107,10 +1082,7 @@ func TestListIdentitiesRespectsOffest(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	// Register multiple identities
 	// These identities can use the same keys...
@@ -1186,10 +1158,7 @@ func TestIdentityDetails(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 
 	// Fetch Identity Details for SovereignIdentity
@@ -1952,10 +1921,7 @@ func TestRealmRoleCRD(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 
 	autoGeneratedRealmRoles, err := identityServiceClient.ListRealmRoles(testContext, realm.Name)
@@ -2038,11 +2004,7 @@ func TestFetchApplicationSecret(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
-
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 
 	realmApplicationCreateParams := CreateRealmApplicationRequest{
@@ -2092,11 +2054,7 @@ func TestFetchApplicationSAMLSDescription(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
-
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 
 	realmApplicationCreateParams := CreateRealmApplicationRequest{
@@ -2157,10 +2115,7 @@ func TestApplicationMapperCRD(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	// Ensure realm is cleaned up even if test fails
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	// Create realm OIDC application
@@ -2262,10 +2217,7 @@ func TestSearchingIdentitiesWithEmailValidRealmReturnsSuccess(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	accountToken := createAccountResponse.AccountServiceToken
 	queenAccountClient := accountClient.New(queenClientInfo)
@@ -2341,10 +2293,7 @@ func TestSearchingIdentitiesWithEmailValidRealmInvalidIdentitiesReturnsSuccess(t
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	requestParam := SearchRealmIdentitiesRequest{
 		RealmName:      realm.Name,
@@ -2370,10 +2319,7 @@ func TestSearchingIdentitiesOnlyReturnsIdentifiersForValidEmails(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	accountToken := createAccountResponse.AccountServiceToken
 	queenAccountClient := accountClient.New(queenClientInfo)
@@ -2453,10 +2399,7 @@ func TestSearchingIdentitiesWithUsernameValidRealmReturnsSuccess(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	accountToken := createAccountResponse.AccountServiceToken
 	queenAccountClient := accountClient.New(queenClientInfo)
@@ -2533,10 +2476,7 @@ func TestSearchingIdentitiesWithUsernameValidRealmInvalidIdentitiesReturnsSucces
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	requestParam := SearchRealmIdentitiesRequest{
 		RealmName:         realm.Name,
@@ -2561,10 +2501,7 @@ func TestSearchingIdentitiesOnlyReturnsIdentifiersForValidUsernames(t *testing.T
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	accountToken := createAccountResponse.AccountServiceToken
 	queenAccountClient := accountClient.New(queenClientInfo)
@@ -2645,10 +2582,7 @@ func TestGetPrivateRealmInfoReturnsSuccessForAuthorizedRealmIdentity(t *testing.
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	//defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	accountToken := createAccountResponse.AccountServiceToken
 	queenAccountClient := accountClient.New(queenClientInfo)
@@ -2716,10 +2650,7 @@ func TestSearchingIdentitiesOnlyReturnsIdentifiersForValidClientIDs(t *testing.T
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	accountToken := createAccountResponse.AccountServiceToken
 	queenAccountClient := accountClient.New(queenClientInfo)
@@ -2800,10 +2731,7 @@ func TestSearchingIdentitiesWithClientIDsValidRealmReturnsSuccess(t *testing.T) 
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	accountToken := createAccountResponse.AccountServiceToken
 	queenAccountClient := accountClient.New(queenClientInfo)
@@ -2881,10 +2809,7 @@ func TestUpdateRealmSetting(t *testing.T) {
 		SovereignName: sovereignName,
 	}
 	// Create Realm
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	// defer delete
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	// Check Current Setttings
@@ -2946,10 +2871,7 @@ func TestUpdateRealmSettingwithNoUpdatedValues(t *testing.T) {
 		SovereignName: sovereignName,
 	}
 	// Create Realm
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v\n", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	// defer delete
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 	// Check Current Setttings
@@ -3009,10 +2931,7 @@ func TestRealmRoleCRUD(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 
 	autoGeneratedRealmRoles, err := identityServiceClient.ListRealmRoles(testContext, realm.Name)
@@ -3126,10 +3045,7 @@ func TestUpdateRole(t *testing.T) {
 		RealmName:     realmName,
 		SovereignName: sovereignName,
 	}
-	realm, err := identityServiceClient.CreateRealm(testContext, params)
-	if err != nil {
-		t.Fatalf("%s realm creation %+v failed using %+v", err, params, identityServiceClient)
-	}
+	realm := createRealmWithParams(t, identityServiceClient, params)
 	defer identityServiceClient.DeleteRealm(testContext, realm.Name)
 
 	autoGeneratedRealmRoles, err := identityServiceClient.ListRealmRoles(testContext, realm.Name)


### PR DESCRIPTION
Improve identityClient_test stability

When running against the development environment tests can randomly fail

- re-order identity test methods, move all helpers to the top of the file
  - this makes it easier to comment out large amount of tests if needed
- increase test suite timeout (20 minutes instead of default 10 minutes)
  - avoid `panic: test timed out after 10m0s` errors when running against development
- refactor uniqueString helper to use random int instead of timestamp
  - ensure we use this helper for all realm names
- add retry for realm creation
  - currently retries once after failure
  - so far in all my test runs a single retry appears to be enough

![image](https://user-images.githubusercontent.com/52154/131534844-50d312cc-533e-40e8-9a6b-870a6e1a36d9.png)
