### PR TITLE
[PLAT-731] token races

### DIFF
--- a/keycloakClient/api.go
+++ b/keycloakClient/api.go
@@ -20,12 +20,18 @@ type TokenInfo struct {
 	refresher        *time.Timer
 }
 
+// tokenMapKey is the key of the `tokens` map on Client
+type tokenMapKey struct {
+	realm    string
+	username string
+}
+
 // Client is the keycloak client which contains a map of current tokens.
 type Client struct {
 	tokenProviderURL                 *url.URL
 	apiURL                           *url.URL
 	httpClient                       *http.Client
-	tokens                           map[string]*TokenInfo
+	tokens                           map[tokenMapKey]*TokenInfo
 	refreshAuthTokenBeforeExpiration int32
 	config                           Config
 }

--- a/keycloakClient/api.go
+++ b/keycloakClient/api.go
@@ -10,12 +10,14 @@ import (
 
 // TokenInfo represents a full oAuth2 JWT token response with expiration and refresh.
 type TokenInfo struct {
-	TokenType      string
-	AccessToken    string
-	Expires        time.Time
-	RefreshToken   string
-	RefreshExpires time.Time
-	refresher      *time.Timer
+	TokenType        string
+	AccessToken      string
+	Expires          time.Time
+	RefreshToken     string
+	RefreshExpires   time.Time
+	autorefreshes    bool
+	onRefreshFailure func(error)
+	refresher        *time.Timer
 }
 
 // Client is the keycloak client which contains a map of current tokens.

--- a/keycloakClient/keycloakClient.go
+++ b/keycloakClient/keycloakClient.go
@@ -145,10 +145,12 @@ func (c *Client) GetTokenInfo(realm string, username string, password string, fo
 	var newTokenInfo *TokenInfo
 	var err error
 	key := realm + username
-	KeycloakTokenInfoLock.Lock()
+
 	// Get exclusive access to the token
+	KeycloakTokenInfoLock.Lock()
+	defer KeycloakTokenInfoLock.Unlock()
+
 	tokenInfo, exists := c.tokens[key]
-	KeycloakTokenInfoLock.Unlock()
 	if !exists || time.Now().After(tokenInfo.RefreshExpires) {
 		// If the token doesn't exist or can no longer be refreshed, get a new token
 		newTokenInfo, err = c.FetchToken(realm, username, password)

--- a/keycloakClient/keycloakClient.go
+++ b/keycloakClient/keycloakClient.go
@@ -79,7 +79,7 @@ func New(config Config) (*Client, error) {
 		tokenProviderURL:                 urlToken,
 		apiURL:                           urlApi,
 		httpClient:                       &httpClient,
-		tokens:                           map[string]*TokenInfo{},
+		tokens:                           map[tokenMapKey]*TokenInfo{},
 		refreshAuthTokenBeforeExpiration: config.RefreshAuthTokenBeforeExpiration,
 		config:                           config,
 	}
@@ -144,7 +144,10 @@ func (t *tokenJSON) toTokenInfo(iat time.Time) *TokenInfo {
 func (c *Client) GetTokenInfo(realm string, username string, password string, force bool) (*TokenInfo, error) {
 	var newTokenInfo *TokenInfo
 	var err error
-	key := realm + username
+	key := tokenMapKey{
+		realm:    realm,
+		username: username,
+	}
 
 	// Get exclusive access to the token
 	KeycloakTokenInfoLock.Lock()


### PR DESCRIPTION
I was digging deeply into a race condition that was causing identitiy management tests to fail, which is the same race condition that causes us to need retry logic on the identity tests in this repo.

Changes to this repo:
* i made the mutex wrap the entire `GetTokenInfo` func. 
  * in the best case where it finds the token in the `tokens` map, it makes three extra boolean checks before releasing the lock. in the worst case, it refreshes & replaces the token. The lock should still be held as a race condition exists in which it locks for read, some other goroutine grabs the token, this code replaces the token (invalidating the old), and then the other goroutine is attempting to use a no longer valid one.
  * as will be seen in my identity management PR, if you grab the token as a string, there is always a race condition in which it could be replaced before you use it. but this reduces that timeframe & provides extra protection.

* autorefreshing tokens that are refreshed will continue to autorefresh.
  * when we refresh a token that has a `refresher` (the func that actually managed the timed refreshing) we never create a new refresher for the new token. this mean that our autorefreshing tokens really only autorefreshed one time before just becoming non-refreshing tokens. i added a `autorefreshes` flag to TokenInfo that will allow previously autorefreshing tokens to be renewed with a new refresher.

* finally, a bug! The `tokens` map used `realm + username` as a key which allows for collisions. example: user `pirtle` at realm `magic` stores his token in the same place as user `irtle` at realm `magicp`. i converted the key to be a struct to avoid the collisions.



As a bonus, I am able to run the identity client test suite and no retires happen 🎉 