### PR TITLE
[WASH-1045] Test locking an Identity's account

### DIFF
--- a/.env
+++ b/.env
@@ -21,6 +21,8 @@ KEYCLOAK_MASTER_REALM=master
 KEYCLOAK_USERNAME=admin
 KEYCLOAK_PASSWORD=password
 IDENTITY_ACCESS_TOKEN_LIFESPAN=3600
+# Identity account lock configuration
+IDENTITY_LOGIN_RETRIES=10
 # Default Session set to 1 day 
 DEFAULT_IDENTITY_SSO_SESSION_IDLE_TIMEOUT=86400
 # Default Session Max without authentication set to 2 weeks 


### PR DESCRIPTION
- Adds a test that writes more audits than the threshold for an
  Identity's account, and confirms that the account becomes locked

Draft PR for now. Still want to do some cleanup.