### PR TITLE
[WR-233] fix typo in api response struct

### DIFF
--- a/identityClient/api.go
+++ b/identityClient/api.go
@@ -981,7 +981,7 @@ type AccessRequest = AccessRequestResponse
 // AccessRequestSearchResponse wraps access requests and pagination values returned
 // from an access request search request
 type AccessRequestSearchResponse struct {
-	AccessReqeusts []AccessRequest `json:"access_requests"`
+	AccessRequests []AccessRequest `json:"access_requests"`
 	NextToken      int64           `json:"next_token"`
 }
 

--- a/identityClient/identityClient_test.go
+++ b/identityClient/identityClient_test.go
@@ -3590,7 +3590,7 @@ func TestSearchForAllSelfCreatedAccessRequests(t *testing.T) {
 	expectedAccessRequestIDs := []int64{firstCreatedAccessRequest.ID, secondCreatedAccessRequest.ID}
 	for _, expectedAccessRequestID := range expectedAccessRequestIDs {
 		var found bool
-		for _, accessRequest := range searchResponse.AccessReqeusts {
+		for _, accessRequest := range searchResponse.AccessRequests {
 			if accessRequest.ID == expectedAccessRequestID {
 				found = true
 				break
@@ -3598,7 +3598,7 @@ func TestSearchForAllSelfCreatedAccessRequests(t *testing.T) {
 
 		}
 		if !found {
-			t.Fatalf("Expected to find created access request %d in search response %+v", expectedAccessRequestID, searchResponse.AccessReqeusts)
+			t.Fatalf("Expected to find created access request %d in search response %+v", expectedAccessRequestID, searchResponse.AccessRequests)
 		}
 	}
 }


### PR DESCRIPTION
fixing this typo i found. will update in identity-management-portal when released.

tests continue to fail due to precondition unmet. the precondition is that mpc_enabled realm setting needs to be true and access policies need to exist.