### PR TITLE
[WR-277] Fix Get Users dropping max param

### DIFF
--- a/.env
+++ b/.env
@@ -23,11 +23,11 @@ KEYCLOAK_PASSWORD=password
 IDENTITY_ACCESS_TOKEN_LIFESPAN=3600
 # Identity account lock configuration
 IDENTITY_LOGIN_RETRIES=10
-# Default Session set to 1 day 
+# Default Session set to 1 day
 DEFAULT_IDENTITY_SSO_SESSION_IDLE_TIMEOUT=86400
-# Default Session Max without authentication set to 2 weeks 
+# Default Session Max without authentication set to 2 weeks
 DEFAULT_IDENTITY_SSO_SESSION_MAX_LIFESPAN=1209600
-# Revokes refresh token after the max use 
+# Revokes refresh token after the max use
 DEFAULT_IDENTITY_REVOKE_REFRESH_TOKEN=true
 # Default is set to use each refresh token once
 DEFAULT_IDENTITY_REFRESH_TOKEN_MAX_REUSE=1

--- a/keycloakClient/keycloakClient.go
+++ b/keycloakClient/keycloakClient.go
@@ -914,7 +914,7 @@ func (c *Client) GetUsers(accessToken string, reqRealmName, targetRealmName stri
 	if len(paramKV) > 0 {
 		urlParams := req.URL.Query()
 		// Sketchy
-		for i := 0; i < len(paramKV)/2; i += 2 {
+		for i := 0; i < len(paramKV); i += 2 {
 			urlParams.Set(paramKV[i], paramKV[i+1])
 		}
 		req.URL.RawQuery = urlParams.Encode()


### PR DESCRIPTION
This will fix a problem with ListIdentities where requested page sizes of 100 or greater only returns one page of results