### PR TITLE
publish previous commits which while unmerged have been deployed to production since Oct 21.

### DIFF
--- a/hookClient/api.go
+++ b/hookClient/api.go
@@ -11,8 +11,9 @@ type HookTrigger struct {
 // CreateHookRequest wraps the parameters
 // required for a valid CreateHook request.
 type CreateHookRequest struct {
-	WebhookURL string        `json:"webhook_url"`
-	Triggers   []HookTrigger `json:"triggers"`
+	WebhookURL    string        `json:"webhook_url"`
+	WebhookSecret string        `json:"webhook_secret"`
+	Triggers      []HookTrigger `json:"triggers"`
 }
 
 // CreateHookResponse represents a response from calling the CreateHook endpoint.


### PR DESCRIPTION
go to build a service that hasn't been changed in over a year, and got this

```
Step 7/17 : RUN go mod download
 ---> Running in 94e8a2c061b5
go mod download: github.com/tozny/e3db-clients-go@v0.0.101-0.20200925182558-d06f88c0fca6: invalid version: unknown revision d06f88c0fca6
```

unpublished commit

https://github.com/tozny/e3db-clients-go/commit/d06f88c0fca6


update matches what the service api is expecting

https://github.com/tozny/hook-service/blob/master/api/api.go#L27

And integration test for the code path continue to pass 

https://github.com/tozny/hook-service/blob/master/hook_test.go#L344
