### PR TITLE
[WR263] LDAP Hook Up upon successful connection

### DIFF
--- a/identityClient/api.go
+++ b/identityClient/api.go
@@ -1099,6 +1099,11 @@ type ConnectFederationSaveRequest struct {
 	Credentials          map[string]string
 }
 
+// ConnectFederationSaveResponse wraps the response to an activation for realm federation
+type ConnectFederationSaveResponse struct {
+	ActiveLDAPProvider Provider
+}
+
 // AccessRequestGroupsRequest wraps parameters needed for fetching the MPC Enabled Realm groups
 type AccessRequestGroupsRequest struct {
 	RealmName string `json:"realm_name"`

--- a/identityClient/identityClient.go
+++ b/identityClient/identityClient.go
@@ -1222,12 +1222,13 @@ func (c *E3dbIdentityClient) ConfigureFederationConnection(ctx context.Context, 
 }
 
 // CompleteFederationConnection handles the activation of a federation request
-func (c *E3dbIdentityClient) CompleteFederationConnection(ctx context.Context, params ConnectFederationSaveRequest) error {
+func (c *E3dbIdentityClient) CompleteFederationConnection(ctx context.Context, params ConnectFederationSaveRequest) (*ConnectFederationSaveResponse, error) {
+	var response *ConnectFederationSaveResponse
 	// Change Host to Primary Realm Endpoint
 	path := params.PrimaryRealmEndpoint + identityServiceBasePath + "/" + federationResourceName + "/activate/" + params.ConnectionID.String()
 	req, err := e3dbClients.CreateRequest(http.MethodPut, path, params)
 	if err != nil {
-		return err
+		return response, err
 	}
 	// Set Credential Token
 	for _, authHeader := range AuthenticationHeaders {
@@ -1237,7 +1238,8 @@ func (c *E3dbIdentityClient) CompleteFederationConnection(ctx context.Context, p
 		}
 	}
 
-	return e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &response)
+	return response, err
 }
 
 // AccessRequestGroup fetches groups for MPC Enabled Realms


### PR DESCRIPTION
Making an API Spec Change but thought it would be easier to show this first:

Current Flow:

Primary Initiates Connection (Queen Auth)

Shadow Configures to hook up to that connection ( Queen Auth) 
* During the hook up, the shadow calls the primary to activate the connection (api credential auth)  <-- **that is this endpoint** 
Currently it just returned success or error now it will return ldap config! 

Next PR will be API Spec 