### PR TITLE
[WR-388] Add GetUserCredentials keycloak method

### DIFF
--- a/identityClient/identityClient.go
+++ b/identityClient/identityClient.go
@@ -1422,7 +1422,7 @@ func (c *E3dbIdentityClient) RegisterMFADevice(ctx context.Context, params Regis
 		return response, err
 	}
 	request.Header.Add(toznySessionHeader, params.SessionToken)
-	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, request, c.SigningKeys, c.ClientID, response)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, request, c.SigningKeys, c.ClientID, &response)
 	return response, err
 }
 
@@ -1434,6 +1434,6 @@ func (c *E3dbIdentityClient) ListIdentitiesMFACredentials(ctx context.Context, p
 	if err != nil {
 		return result, err
 	}
-	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, request, c.SigningKeys, c.ClientID, result)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, request, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }

--- a/keycloakClient/keycloakClient.go
+++ b/keycloakClient/keycloakClient.go
@@ -1158,6 +1158,12 @@ func (c *Client) RegisterWebAuthnDevice(accessToken, sessionToken, realmDomain s
 	return err
 }
 
+func (c *Client) GetUserCredentials(accessToken string, realmName, userID string) ([]CredentialRepresentation, error) {
+	var resp = []CredentialRepresentation{}
+	var err = c.get(accessToken, &resp, fmt.Sprintf("%s/%s/%s/%s/credentials", realmRootPath, realmName, userResourceName, userID))
+	return resp, err
+}
+
 // requestWithQueryParams creates a request with query params
 func (c *Client) requestWithQueryParams(accessToken string, req *http.Request, data interface{}) error {
 	req, err := setAuthorizationAndHostHeaders(req, accessToken)


### PR DESCRIPTION
Fixes a bug in which a reference to the response object was not being passed into `MakeSignedServiceCall` for `ListIdentitiesMFACredentials` and `RegisterMFADevice`. 

Adds a new Keycloak Client method to call Keycloak's `/credentials` endpoint, which returns a list populated with each credential the user has. 