### PR TITLE
[WR-387] change login context from string -> interface{}

### DIFF
--- a/identityClient/api.go
+++ b/identityClient/api.go
@@ -171,19 +171,19 @@ type InitialLoginResponse struct {
 	NoteID                                 string `json:"note_id"`
 }
 
-// IdentitySessionRequestResponse is returned by the IdentitySesssionRequest. It contains data related to what additional
+// IdentitySessionRequestResponse is returned by the IdentitySessionRequest. It contains data related to what additional
 // actions are needed to create a session and how to create the session
 type IdentitySessionRequestResponse struct {
 	LoginAction     bool                   `json:"login_action"`
 	LoginActionType string                 `json:"type"`
 	ActionURL       string                 `json:"action_url"`
 	Fields          map[string]string      `json:"fields"`
-	Context         map[string]string      `json:"context"`
+	Context         map[string]interface{} `json:"context"`
 	ContentType     string                 `json:"content_type"`
 	Message         SessionResponseMessage `json:"message"`
 }
 
-// SessionResponseMessage provides information reagarding the error status of login actions
+// SessionResponseMessage provides information regarding the error status of login actions
 // IsError is the most reliable source of information if the login action was successful or not
 type SessionResponseMessage struct {
 	Summary     string `json:"summary"`


### PR DESCRIPTION
though we haven't made use of them, the login context can be more than
just strings. it is especially helpful to be anything so that it can
be a list of items.

**this is a breaking change**, as previously used login context values must
now be cast to strings.

i'm open for debate on whether or not this change should happen in this way. my main justification is that we state this repo is for internal use and this makes all login flow funcs more powerful.

it is used by one handler in identity service & the login method of e3db-go. if we implemented this change by introducing another client method with the new return type, both these login flow uses would need updated to the new thing.

my primary motivation for this is that the webauthn login flow should support multiple authentication devices. part of the process is sending information about the identity's registered devices so that the hardware security device(s) know which public key ids should be used to sign the login challenge.