### PR TITLE
[WR-414] add method for listing auth providers

### DIFF
--- a/keycloakClient/api.go
+++ b/keycloakClient/api.go
@@ -83,6 +83,13 @@ type AuthenticatorConfigRepresentation struct {
 	Id     *string                 `json:"id,omitempty"`
 }
 
+// AuthenticatorProvider is a stub of an authenticator available to an execution or auth flow
+type AuthenticatorProvider struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+}
+
 type ClientTemplateRepresentation struct {
 	Attributes                *map[string]interface{}         `json:"attributes,omitempty"`
 	BearerOnly                *bool                           `json:"bearerOnly,omitempty"`

--- a/keycloakClient/keycloakClient.go
+++ b/keycloakClient/keycloakClient.go
@@ -1054,6 +1054,14 @@ func (c *Client) GetUserFederationProviders(accessToken string, realmName string
 	return resp, err
 }
 
+// ListAuthenticatorProviders lists the available auth providers that can be used in auth flow executions
+func (c *Client) ListAuthenticatorProviders(accessToken, realmName string) ([]AuthenticatorProvider, error) {
+	resp := []AuthenticatorProvider{}
+	url := fmt.Sprintf("%s/%s/%s/authenticator-providers", realmRootPath, realmName, authenticationResourceName)
+	err := c.get(accessToken, &resp, url)
+	return resp, err
+}
+
 // CreateAuthenticationExecutionForFlow add a new authentication execution to a flow.
 // 'flowAlias' is the alias of the parent flow.
 func (c *Client) CreateAuthenticationExecutionForFlow(accessToken string, realmName, flowAlias, provider string) (string, error) {


### PR DESCRIPTION
listing the auth providers allows us to check if an auth provider exists
before attempting to add it to an auth flow execution.