### PR TITLE
[Plat-943] added GetGroupRecordsByRecordID to storageClient.go

### DIFF
--- a/storageClient/api.go
+++ b/storageClient/api.go
@@ -108,6 +108,17 @@ type ListGroupsResponse struct {
 	NextToken int64   `json:"next_token"`
 }
 
+// TODO comment
+type GetGroupRecordsRequest struct {
+	RecordIDs []string  `json:"record_ids"`
+	ReaderID  uuid.UUID `json:"reader_id"`
+}
+
+// TODO comment
+type GetGroupRecordsResponse struct {
+	ResultList []pdsClient.ListedRecord `json:"results"`
+}
+
 // AddingCapabilityRequest wraps values used to add a capability for Groups.
 type AddingCapabilityRequest struct {
 	ClientID       uuid.UUID `json:"client_id"`

--- a/storageClient/storageClient.go
+++ b/storageClient/storageClient.go
@@ -695,3 +695,15 @@ func (c *StorageClient) InternalGroupModifiedAllowedReadsBatch(ctx context.Conte
 	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
+
+//TODO comment
+func (c *StorageClient) GetGroupRecordsByRecordID(ctx context.Context, params GetGroupRecordsRequest) (*GetGroupRecordsResponse, error) {
+	var result *GetGroupRecordsResponse
+	path := c.Host + "/internal" + storageServiceBasePath + "/groups/search"
+	req, err := e3dbClients.CreateRequest("POST", path, params)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
+	return result, err
+}

--- a/storageClient/storageClient.go
+++ b/storageClient/storageClient.go
@@ -696,7 +696,7 @@ func (c *StorageClient) InternalGroupModifiedAllowedReadsBatch(ctx context.Conte
 	return result, err
 }
 
-//TODO comment
+// GetGroupRecordsByRecordID Fetches records shared with groups based on search query
 func (c *StorageClient) GetGroupRecordsByRecordID(ctx context.Context, params GetGroupRecordsRequest) (*GetGroupRecordsResponse, error) {
 	var result *GetGroupRecordsResponse
 	path := c.Host + "/internal" + storageServiceBasePath + "/groups/search"


### PR DESCRIPTION
Trying to add new groups/search but TestGetGroupRecordsByRecordID in groups_test in storage service is getting "err = e3db: http://platform.local.tozny.com:8000/internal/v2/storage/groups/search: server http error 404"
