### PR TITLE
New API wrapper for internal delete group members.

### DIFF
--- a/storageClient/api.go
+++ b/storageClient/api.go
@@ -144,6 +144,11 @@ type GroupMember struct {
 	CapabilityNames []string  `json:"capability_names"`
 }
 
+// StorageService Internal Delete Group Members.
+type SSInternalDeleteGroupMember struct {
+	GroupMembers []uuid.UUID `json:"group_members"`
+}
+
 // DeleteGroupMembersRequest  wraps the information of all members being removed from group provided.
 type DeleteGroupMembersRequest AddGroupMembersRequest
 
@@ -493,7 +498,7 @@ type OutgoingSharePolicy struct {
 	RecordType string `json:"record_type"`
 }
 
-//InternalFetchGroupInfo wraps the Capability for the Client with the Groups they are authorized for
+// InternalFetchGroupInfo wraps the Capability for the Client with the Groups they are authorized for
 type InternalFetchGroupInfo struct {
 	GroupIDs   []uuid.UUID `json:"group_ids"`
 	Capability string      `json:"capability"`
@@ -504,7 +509,7 @@ type InternalFetchClientMembershipResponse struct {
 	Groups []InternalFetchGroupInfo `json:"groups"`
 }
 
-//InternalFetchClientMembership wraps all values needed for fetching a client's group membership for a given capability
+// InternalFetchClientMembership wraps all values needed for fetching a client's group membership for a given capability
 type InternalFetchClientMembership struct {
 	ClientID     uuid.UUID `json:"client_id"`
 	Capabilities []string  `json:"capabilities"`

--- a/storageClient/storageClient.go
+++ b/storageClient/storageClient.go
@@ -31,7 +31,7 @@ var (
 	EACPHeaders = []string{TozIDLoginTokenHeader}
 )
 
-//StorageClient implements an http client for communication with the storage service.
+// StorageClient implements an http client for communication with the storage service.
 type StorageClient struct {
 	ClientID       string
 	SigningKeys    e3dbClients.SigningKeys
@@ -186,6 +186,17 @@ func (c *StorageClient) DeleteGroupMembers(ctx context.Context, params DeleteGro
 		return err
 	}
 
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
+	return err
+}
+
+// InternalDeleteGroupMembers removes member from tozstore group.
+func (c *StorageClient) InternalDeleteGroupMembers(ctx context.Context, groupId string, params SSInternalDeleteGroupMember) error {
+	path := c.Host + "/internal" + storageServiceBasePath + "/groups/" + groupId + "/members"
+	req, err := e3dbClients.CreateRequest("DELETE", path, params)
+	if err != nil {
+		return err
+	}
 	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 	return err
 }
@@ -692,7 +703,7 @@ func (c *StorageClient) InternalGetNoteInfo(ctx context.Context, noteName string
 	return result, err
 }
 
-//InternalClientGroupMembershipFetch is an internal endpoint used to fetch a clients membership within a group for given capabilities
+// InternalClientGroupMembershipFetch is an internal endpoint used to fetch a clients membership within a group for given capabilities
 func (c *StorageClient) InternalClientGroupMembershipFetch(ctx context.Context, params InternalFetchClientMembership) (*InternalFetchClientMembershipResponse, error) {
 	var result *InternalFetchClientMembershipResponse
 	path := c.Host + "/internal" + storageServiceBasePath + "/groups"


### PR DESCRIPTION
A new API wrapper which calls Storage Service 2 to remove user from tozstore group when their access is expired.