### PR TITLE
Update eacp email.

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -663,6 +663,19 @@ func DeriveIdentityCredentials(username string, password string, realmName strin
 	return noteName, cryptoKeyPair, signingKeyPair, nil
 }
 
+// DeriveBrokerKeyNoteName derives a broker otp note name for the given parameters
+func DeriveBrokerKeyNoteName(username string, realmName string) (string, error) {
+	nameSeed := fmt.Sprintf("brokerKey:%s@realm:%s", username, realmName)
+	hashedMessageAccumlator, err := blake2b.New(Blake2BBytes, nil)
+	if err != nil {
+		return "", err
+	}
+	hashedMessageAccumlator.Write([]byte(nameSeed))
+	hashedMessageBytes := hashedMessageAccumlator.Sum(nil)
+	noteName := Base64Encode(hashedMessageBytes)
+	return noteName, err
+}
+
 type EncryptedFileInfo struct {
 	EncryptedFileName string
 	Size              int

--- a/storageClient/storageClient.go
+++ b/storageClient/storageClient.go
@@ -901,3 +901,14 @@ func (c *StorageClient) AdminListAllGroups(ctx context.Context, params AdminList
 	return result, err
 
 }
+
+// InternalUpdateEACPEmail updates eacp email.
+func (c *StorageClient) InternalUpdateEACPEmail(ctx context.Context, params map[string]interface{}) error {
+	path := c.Host + "/internal" + storageServiceBasePath + "/notes/eacp/email"
+	req, err := e3dbClients.CreateRequest("PATCH", path, params)
+	if err != nil {
+		return err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
+	return err
+}


### PR DESCRIPTION
- Email update requires update in storage service's email_eacp table. So new storage service internal API wrapper is added. This is used to call SS from Identity Service.