### PR TITLE
Tozflow 691 internal clientinfo

### DIFF
--- a/clientServiceClient/api.go
+++ b/clientServiceClient/api.go
@@ -155,8 +155,8 @@ type InternalClientListResponse struct {
 }
 
 type ClientInfo struct {
-	ClientID string `json:"client_id"`
-	Status   bool   `json:"status"`
+	ClientID  string `json:"client_id"`
+	IsDeleted bool   `json:"status"`
 }
 type InternalClientInfoListResponse struct {
 	Clients   []ClientInfo `json:"client_ids"`

--- a/clientServiceClient/api.go
+++ b/clientServiceClient/api.go
@@ -153,3 +153,12 @@ type InternalClientListResponse struct {
 	ClientIDs []string `json:"client_ids"`
 	NextToken int64    `json:"next_token"`
 }
+
+type ClientInfo struct {
+	ClientID string `json:"client_id"`
+	Status   bool   `json:"status"`
+}
+type InternalClientInfoListResponse struct {
+	Clients   []ClientInfo `json:"client_ids"`
+	NextToken int64        `json:"next_token"`
+}

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -84,6 +84,17 @@ func (c *ClientServiceClient) InternalDeleteClient(ctx context.Context, realmNam
 	return err
 }
 
+// InternalUpdateClientDelete makes authenticated call to the /internal endpoint for client service.
+func (c *ClientServiceClient) InternalUpdateClientDelete(ctx context.Context, clientID string) error {
+	path := c.Host + "/internal/" + ClientServiceBasePath + "/clients/" + clientID + "/delete"
+	req, err := e3dbClients.CreateRequest("PUT", path, nil)
+	if err != nil {
+		return err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, nil)
+	return err
+}
+
 // Register registers a client.
 func (c *ClientServiceClient) Register(ctx context.Context, params ClientRegisterRequest) (*ClientRegisterResponse, error) {
 	var result *ClientRegisterResponse

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -86,7 +86,7 @@ func (c *ClientServiceClient) InternalDeleteClient(ctx context.Context, realmNam
 
 // InternalUpdateClientDelete makes authenticated call to the /internal endpoint for client service.
 func (c *ClientServiceClient) InternalUpdateClientDelete(ctx context.Context, clientID string) error {
-	path := c.Host + "/internal/" + ClientServiceBasePath + clientID + "/delete"
+	path := c.Host + "/internal/" + ClientServiceBasePath + "clients/" + clientID + "/delete"
 	req, err := e3dbClients.CreateRequest("PUT", path, nil)
 	if err != nil {
 		return err

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -224,6 +224,23 @@ func (c *ClientServiceClient) InternalClientList(ctx context.Context, params Int
 	return result, err
 }
 
+// InternalClientInfoList calls internal endpoint to return all clients with status. This endpoint is paginated.
+// The last page will containe a next token equal to 0
+func (c *ClientServiceClient) InternalClientInfoList(ctx context.Context, params InternalClientListRequest) (*InternalClientInfoListResponse, error) {
+	var result *InternalClientInfoListResponse
+	path := c.Host + "/internal/" + ClientServiceBasePath + "clients"
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return result, err
+	}
+	urlParams := req.URL.Query()
+	urlParams.Set("next", strconv.Itoa(int(params.NextToken)))
+	urlParams.Set("limit", strconv.Itoa(int(params.Limit)))
+	req.URL.RawQuery = urlParams.Encode()
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, &result)
+	return result, err
+}
+
 // AdminToggleClientEnabled enables/disables clients with account auth.
 func (c *ClientServiceClient) InternalToggleClientEnabled(ctx context.Context, params InternalToggleEnabledRequest) error {
 	path := c.Host + "/internal/" + ClientServiceBasePath + params.ClientID + "/enable"

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -228,7 +228,7 @@ func (c *ClientServiceClient) InternalClientList(ctx context.Context, params Int
 // The last page will containe a next token equal to 0
 func (c *ClientServiceClient) InternalClientInfoList(ctx context.Context, params InternalClientListRequest) (*InternalClientInfoListResponse, error) {
 	var result *InternalClientInfoListResponse
-	path := c.Host + "/internal/" + ClientServiceBasePath + "clients"
+	path := c.Host + "/internal/" + ClientServiceBasePath + "clients/info"
 	req, err := e3dbClients.CreateRequest("GET", path, nil)
 	if err != nil {
 		return result, err

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -86,7 +86,7 @@ func (c *ClientServiceClient) InternalDeleteClient(ctx context.Context, realmNam
 
 // InternalUpdateClientDelete makes authenticated call to the /internal endpoint for client service.
 func (c *ClientServiceClient) InternalUpdateClientDelete(ctx context.Context, clientID string) error {
-	path := c.Host + "/internal/" + ClientServiceBasePath + "/clients/" + clientID + "/delete"
+	path := c.Host + "/internal/" + ClientServiceBasePath + clientID + "/delete"
 	req, err := e3dbClients.CreateRequest("PUT", path, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
Two API endpoints:
1. Get all clients with IsDeleted status.
2. Reset cleanup table row so that client delete routine will clean un-shared floating records.