### PR TITLE
Edit mode added to provider connection settings.

### DIFF
--- a/identityClient/api.go
+++ b/identityClient/api.go
@@ -640,6 +640,7 @@ type Provider struct {
 type ProviderConnectionSettings struct {
 	Type                  string   `json:"type"`
 	IdentityNameAttribute string   `json:"identity_name_attribute"`
+	EditMode              string   `json:"edit_mode"`
 	RDNAttribute          string   `json:"rdn_attribute"`
 	UUIDAttribute         string   `json:"uuid_attribute"`
 	IdentityObjectClasses []string `json:"identity_object_classes"`


### PR DESCRIPTION
Edit Mode filed in User Federation Provider creation(Ex:LDAP) became mandatory in KC19 so this has been added to our terraform provider.
https://github.com/tozny/terraform-provider-tozny/tree/WR-595-Keycloak-Upgrade