### PR TITLE
User delete enhancement. Client cleanup API changes.

### DIFF
--- a/clientServiceClient/api.go
+++ b/clientServiceClient/api.go
@@ -162,3 +162,9 @@ type InternalClientInfoListResponse struct {
 	Clients   []ClientInfo `json:"client_ids"`
 	NextToken int64        `json:"next_token"`
 }
+
+type InternalClientDeleteRequest struct {
+	RealmName    string `json:"realm_name"`
+	ClientID     string `json:"client_id"`
+	DeleteShared string `json:"delete_shared"`
+}

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -74,13 +74,13 @@ func (c *ClientServiceClient) AdminToggleClientEnabled(ctx context.Context, para
 }
 
 // InternalDeleteClient makes authenticated call to the /internal endpoint for client service.
-func (c *ClientServiceClient) InternalDeleteClient(ctx context.Context, realmName string, clientID string) error {
-	path := c.Host + "/internal/" + ClientServiceBasePath + "realm/" + realmName + "/client/" + clientID
-	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
+func (c *ClientServiceClient) InternalDeleteClient(ctx context.Context, params InternalClientDeleteRequest) error {
+	path := c.Host + "/internal/" + ClientServiceBasePath + "delete"
+	req, err := e3dbClients.CreateRequest("POST", path, params)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, nil)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, params)
 	return err
 }
 

--- a/storageClient/api.go
+++ b/storageClient/api.go
@@ -693,8 +693,9 @@ type GetClientOnlyAdminGroupsResponse struct {
 }
 
 type DeleteClientDataRequest struct {
-	ClientID  string `json:"client_id"`
-	RealmName string `json:"realm_name"`
+	ClientID     string `json:"client_id"`
+	RealmName    string `json:"realm_name"`
+	DeleteShared bool   `json:"delete_shared_records,omitempty"`
 }
 
 type GroupFolder struct {


### PR DESCRIPTION
Added new attribute to pass delete_shared_records as option to delete endpoint. Adjusted API method from DELETE to POST and modified URL as well.