### PR TITLE
Revert user delete enhancement changes

### DIFF
--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -76,7 +76,7 @@ func (c *ClientServiceClient) AdminToggleClientEnabled(ctx context.Context, para
 // InternalDeleteClient makes authenticated call to the /internal endpoint for client service.
 func (c *ClientServiceClient) InternalDeleteClient(ctx context.Context, realmName string, clientID string) error {
 	path := c.Host + "/internal/" + ClientServiceBasePath + "realm/" + realmName + "/client/" + clientID
-	req, err := e3dbClients.CreateRequest("POST", path, nil)
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -74,13 +74,13 @@ func (c *ClientServiceClient) AdminToggleClientEnabled(ctx context.Context, para
 }
 
 // InternalDeleteClient makes authenticated call to the /internal endpoint for client service.
-func (c *ClientServiceClient) InternalDeleteClient(ctx context.Context, params InternalClientDeleteRequest) error {
-	path := c.Host + "/internal/" + ClientServiceBasePath + "delete"
-	req, err := e3dbClients.CreateRequest("POST", path, params)
+func (c *ClientServiceClient) InternalDeleteClient(ctx context.Context, realmName string, clientID string) error {
+	path := c.Host + "/internal/" + ClientServiceBasePath + "realm/" + realmName + "/client/" + clientID
+	req, err := e3dbClients.CreateRequest("POST", path, nil)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, params)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, nil)
 	return err
 }
 


### PR DESCRIPTION
Description:
I had merged user delete enhancement API changes which should not be until all the dependent services got tested. So i have to revert it because it impacts IDMS.

This is a revert of this PR https://github.com/tozny/e3db-clients-go/pull/376

Test:
When a user is deleted from Flow Identities all of their shared records will not be deleted. This change actually introduced a new option to force delete all shared records but it is put on hold.