### PR TITLE
Tozscrt 64 implement user storage limit

### DIFF
--- a/activityClient/activityClient.go
+++ b/activityClient/activityClient.go
@@ -63,3 +63,45 @@ func (c *E3dbActivityClient) HealthCheck(ctx context.Context) error {
 	err = e3dbClients.MakeRawServiceCall(c.requester, req, nil)
 	return err
 }
+
+func (c *E3dbActivityClient) InternalAddNotification(ctx context.Context, params AddNotificationsRequest) error {
+	path := c.Host + "/internal" + ActivityServiceBasePath + "/notifications"
+	req, err := e3dbClients.CreateRequest("POST", path, params)
+	if err != nil {
+		return err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
+	return err
+}
+
+func (c *E3dbActivityClient) GetNotification(ctx context.Context) (*NotificationsResponse, error) {
+	var result *NotificationsResponse
+	path := c.Host + ActivityServiceBasePath + "/notifications"
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
+	return result, err
+}
+
+func (c *E3dbActivityClient) GetUnreadNotificationsCount(ctx context.Context) (*NotificationCountResponse, error) {
+	var result *NotificationCountResponse
+	path := c.Host + ActivityServiceBasePath + "/notifications/unread/count"
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
+	return result, err
+}
+
+func (c *E3dbActivityClient) UpdateNotificationsStatus(ctx context.Context, params UpdateNotificationsStatus) error {
+	path := c.Host + ActivityServiceBasePath + "/notifications/status/update"
+	req, err := e3dbClients.CreateRequest("POST", path, params)
+	if err != nil {
+		return err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
+	return err
+}

--- a/activityClient/api.go
+++ b/activityClient/api.go
@@ -1,0 +1,28 @@
+package activityClient
+
+type Notification struct {
+	NotificationID   string                 `json:"notification_id"`
+	EventType        string                 `json:"event_type"`
+	ActorClientID    string                 `json:"actor_client_id"`
+	ReceiverClientID string                 `json:"receiver_client_id"`
+	Data             map[string]interface{} `json:"data"`
+	RequestTime      string                 `json:"request_time"`
+}
+
+type AddNotificationsRequest struct {
+	Notifications []Notification `json:"notifications"`
+}
+
+type NotificationsResponse struct {
+	Notifications []Notification `json:"notifications"`
+	NextToken     int            `json:"next_token"`
+}
+
+type NotificationCountResponse struct {
+	Count string `json:"count"`
+}
+
+type UpdateNotificationsStatus struct {
+	Status          string   `json:"status"`
+	NotificationIDs []string `json:"notification_ids"`
+}

--- a/clientServiceClient/clientServiceClient.go
+++ b/clientServiceClient/clientServiceClient.go
@@ -74,13 +74,13 @@ func (c *ClientServiceClient) AdminToggleClientEnabled(ctx context.Context, para
 }
 
 // InternalDeleteClient makes authenticated call to the /internal endpoint for client service.
-func (c *ClientServiceClient) InternalDeleteClient(ctx context.Context, params InternalClientDeleteRequest) error {
-	path := c.Host + "/internal/" + ClientServiceBasePath + "delete"
-	req, err := e3dbClients.CreateRequest("POST", path, params)
+func (c *ClientServiceClient) InternalDeleteClient(ctx context.Context, realmName string, clientID string) error {
+	path := c.Host + "/internal/" + ClientServiceBasePath + "realm/" + realmName + "/client/" + clientID
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
 	if err != nil {
 		return err
 	}
-	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, params)
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, nil)
 	return err
 }
 

--- a/identityClient/api.go
+++ b/identityClient/api.go
@@ -1553,6 +1553,17 @@ type IdentityInfo struct {
 	Attributes map[string][]string `json:"attributes"`
 }
 
+type MPCGroupInfo struct {
+	Name              string   `json:"group_name"`
+	ApproverClientIDS []string `json:"approver_client_ids"`
+}
+
+type AccessRequestInfo struct {
+	RequestorID string `json:"requestor_id"`
+	GroupName   string `json:"group_name"`
+	GroupID     string `json:"group_id"`
+}
+
 // IdentityInfoList wraps a slice of identities and a next token for pagination.
 type IdentityInfoList struct {
 	Identities []IdentityInfo `json:"identities"`

--- a/identityClient/api.go
+++ b/identityClient/api.go
@@ -168,6 +168,12 @@ type RegisterIdentityResponse struct {
 	RealmBrokerIdentityToznyID uuid.UUID `json:"realm_broker_identity_tozny_id,omitempty"`
 }
 
+type RealmAttribute struct {
+	Name  string `pg:"name"`
+	ID    string `pg:"realm_id"`
+	Value string `pg:"value"`
+}
+
 // IdentityLoginRequest wraps parameters needed to initiate an identity login session.
 type IdentityLoginRequest struct {
 	Username    string `json:"username"`

--- a/identityClient/identityClient.go
+++ b/identityClient/identityClient.go
@@ -1729,3 +1729,39 @@ func (c *E3dbIdentityClient) InitiateIdentityProviderLogin(ctx context.Context, 
 	err = e3dbClients.MakeRawServiceCall(c.requester, req, &resp)
 	return resp, err
 }
+
+// InternalGetClientInfo gets client information from identity service
+func (c *E3dbIdentityClient) InternalGetClientInfo(ctx context.Context, clientID string) (IdentityInfo, error) {
+	var response IdentityInfo
+	path := c.Host + internalIdentityServiceBasePath + "/clients/" + clientID
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return response, err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &response)
+	return response, err
+}
+
+// InternalGetMPCGroupInfo gets MPC group information from identity service
+func (c *E3dbIdentityClient) InternalGetMPCGroupInfo(ctx context.Context, groupID string) (MPCGroupInfo, error) {
+	var response MPCGroupInfo
+	path := c.Host + internalIdentityServiceBasePath + "/pam/groups/" + groupID
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return response, err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &response)
+	return response, err
+}
+
+// InternalGetAcessRequestInfo gets information by Access Request ID.
+func (c *E3dbIdentityClient) InternalGetAccessRequestInfo(ctx context.Context, accessRequestID string) (AccessRequestInfo, error) {
+	var response AccessRequestInfo
+	path := c.Host + internalIdentityServiceBasePath + "/pam/access_requests/" + accessRequestID
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return response, err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &response)
+	return response, err
+}

--- a/identityClient/identityClient.go
+++ b/identityClient/identityClient.go
@@ -890,6 +890,18 @@ func (c *E3dbIdentityClient) UpdateIdentityAttributes(ctx context.Context, param
 	return e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
 }
 
+// UpdateIdentityAttributes updates requested identity's attributes
+func (c *E3dbIdentityClient) GetRealmAttributeById(ctx context.Context, realmName string) (*RealmAttribute, error) {
+	var realmAttribute *RealmAttribute
+	path := c.Host + identityServiceBasePath + realmResourceName + "/" + "info" + "/" + realmName + "/" + "storage" + "/" + "limit"
+	req, err := e3dbClients.CreateRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return realmAttribute, err
+	}
+	err = e3dbClients.MakeRawServiceCall(c.requester, req, &realmAttribute)
+	return realmAttribute, err
+}
+
 // DeleteIdentity removes an identity in the given realm.
 func (c *E3dbIdentityClient) DeleteIdentity(ctx context.Context, params RealmIdentityRequest) error {
 	path := c.Host + identityServiceBasePath + "/" + realmResourceName + "/" + params.RealmName + "/" + identityResourceName + "/" + params.IdentityID

--- a/storageClient/api.go
+++ b/storageClient/api.go
@@ -32,6 +32,12 @@ type Note struct {
 	IsSecret            bool              `json:"is_secret"`
 }
 
+type RealmStorageRequest struct {
+	RealmID      string    `json:"realm_id"`
+	StorageLimit string    `json:"storage_limit"`
+	UserID       uuid.UUID `pg:"user_id"`
+}
+
 // InternalNoteInfoResponse wraps a response from the internal NotesInfo endpoint
 type InternalNoteInfoResponse struct {
 	PublicRecipientSigningKey string `json:"public_recipient_signing_key"`
@@ -340,6 +346,10 @@ type PrimeRequestBody struct {
 	OTP *OTPRequest `json:"otp"`
 }
 
+type UserStorage struct {
+	UserID       uuid.UUID `pg:"user_id"`
+	TotalStorage string    `pg:"total_storage"`
+}
 type OTPResponse struct {
 	Password string `json:"password"`
 }

--- a/storageClient/storageClient.go
+++ b/storageClient/storageClient.go
@@ -1140,3 +1140,25 @@ func (c *StorageClient) CommitNoteFile(ctx context.Context, pendingFileID uuid.U
 	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
 	return result, err
 }
+
+func (c *StorageClient) InternalGetRecordsByType(ctx context.Context, recordType string) ([]*Meta, error) {
+	var result []*Meta
+	path := c.Host + "/internal" + storageServiceBasePath + "/records/type/" + recordType
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
+	return result, err
+}
+
+func (c *StorageClient) InternalGetGroupInfo(ctx context.Context, groupID string) (*GroupsWithMembers, error) {
+	var result *GroupsWithMembers
+	path := c.Host + "/internal" + storageServiceBasePath + "/groups/" + groupID
+	req, err := e3dbClients.CreateRequest("GET", path, nil)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, &result)
+	return result, err
+}

--- a/storageClient/storageClient.go
+++ b/storageClient/storageClient.go
@@ -826,6 +826,45 @@ func (c *StorageClient) InternalGetNoteInfo(ctx context.Context, noteName string
 	return result, err
 }
 
+func (c *StorageClient) WriteUserStorageLimit(ctx context.Context, realmId string, body UserStorage) error {
+	path := c.Host + "/internal" + storageServiceBasePath + "/realm" + "/" + realmId + "/storage/limit"
+	req, err := e3dbClients.CreateRequest("POST", path, body)
+	if err != nil {
+		return err
+	}
+	urlParams := req.URL.Query()
+	urlParams.Set("realmId", realmId)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
+	return err
+}
+
+// PrimeByNoteName primes the note with the provided noteName
+func (c *StorageClient) DeleteRealmStorageLimit(ctx context.Context, realmId string) error {
+	path := c.Host + "/internal" + storageServiceBasePath + "/realm" + "/" + realmId + "/storage/limit"
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+	urlParams := req.URL.Query()
+	urlParams.Set("realmId", realmId)
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
+	return err
+}
+
+// PrimeByNoteName primes the note with the provided noteName
+func (c *StorageClient) DeleteUserStorageLimitForUser(ctx context.Context, realmId string, userId uuid.UUID) error {
+	path := c.Host + "/internal" + storageServiceBasePath + "/realm" + "/" + realmId + "/" + userId.String() + "/storage/limit"
+	req, err := e3dbClients.CreateRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+	urlParams := req.URL.Query()
+	urlParams.Set("realmId", realmId)
+	urlParams.Set("userId", userId.String())
+	err = e3dbClients.MakeSignedServiceCall(ctx, c.requester, req, c.SigningKeys, c.ClientID, nil)
+	return err
+}
+
 // InternalClientGroupMembershipFetch is an internal endpoint used to fetch a clients membership within a group for given capabilities
 func (c *StorageClient) InternalClientGroupMembershipFetch(ctx context.Context, params InternalFetchClientMembership) (*InternalFetchClientMembershipResponse, error) {
 	var result *InternalFetchClientMembershipResponse


### PR DESCRIPTION
Description:
1. When Realm created , we need to store the user's storage limit for each user via storage client using " WriteUserStorageLimit"
2. Deleting Realm and Deleting users in the realm , we need to delete the data in the user storage table. To do so,we are calling "DeleteRealmStorageLimit" and "DeleteUserStorageLimitForUser" end points.

To be more secure, we are not exposed those endpoints. We are calling from identity service as internal calls.