### PR TITLE
Return error message from downstream service.

### DIFF
--- a/keycloakClient/keycloakClient.go
+++ b/keycloakClient/keycloakClient.go
@@ -313,29 +313,6 @@ func (c *Client) post(accessToken string, data interface{}, url string) (string,
 	}
 	response, err := e3dbClients.ReturnRawServiceCall(c.httpClient, req, nil)
 	if err != nil {
-		return "", e3dbClients.NewError(err.Error(), path, response.StatusCode)
-	}
-	location := response.Header.Get("Location")
-	return location, nil
-
-}
-func (c *Client) postV2(accessToken string, data interface{}, url string) (string, error) {
-	path := c.apiURL.String() + url
-	buf := &bytes.Buffer{}
-	err := json.NewEncoder(buf).Encode(data)
-	if err != nil {
-		return "", err
-	}
-	req, err := http.NewRequest("POST", path, buf)
-	if err != nil {
-		return "", err
-	}
-	req, err = setAuthorizationAndHostHeaders(req, accessToken)
-	if err != nil {
-		return "", err
-	}
-	response, err := e3dbClients.ReturnRawServiceCall(c.httpClient, req, nil)
-	if err != nil {
 		return "", err
 	}
 	location := response.Header.Get("Location")
@@ -913,7 +890,7 @@ func (c *Client) GetUsers(accessToken string, reqRealmName, targetRealmName stri
 
 // CreateUser creates the user from its UserRepresentation. The username must be unique.
 func (c *Client) CreateUser(accessToken string, reqRealmName, targetRealmName string, user UserRepresentation) (string, error) {
-	return c.postV2(accessToken, user, fmt.Sprintf("%s/%s/%s", realmRootPath, targetRealmName, userResourceName))
+	return c.post(accessToken, user, fmt.Sprintf("%s/%s/%s", realmRootPath, targetRealmName, userResourceName))
 
 }
 
@@ -1081,7 +1058,7 @@ func (c *Client) GetUserFederationProviderMapper(accessToken string, realmName, 
 // CreateUserFederationProviderMapper creates a user federation provider mapper for a realm for mapping attributes from
 // synced users from an external source, returning the location of the created provider mapper or error (if any).
 func (c *Client) CreateUserFederationProviderMapper(accessToken string, realmName string, userFederationProviderMapper UserFederationProviderMapperRepresentation) (string, error) {
-	return c.postV2(accessToken, userFederationProviderMapper, fmt.Sprintf("%s/%s/%s", realmRootPath, realmName, componentsResourceName))
+	return c.post(accessToken, userFederationProviderMapper, fmt.Sprintf("%s/%s/%s", realmRootPath, realmName, componentsResourceName))
 }
 
 // GetUserFederationProviderMappers returns a list of UserFederationProviderMappers belonging to the realm

--- a/keycloakClient/keycloakClient.go
+++ b/keycloakClient/keycloakClient.go
@@ -913,7 +913,7 @@ func (c *Client) GetUsers(accessToken string, reqRealmName, targetRealmName stri
 
 // CreateUser creates the user from its UserRepresentation. The username must be unique.
 func (c *Client) CreateUser(accessToken string, reqRealmName, targetRealmName string, user UserRepresentation) (string, error) {
-	return c.post(accessToken, user, fmt.Sprintf("%s/%s/%s", realmRootPath, targetRealmName, userResourceName))
+	return c.postV2(accessToken, user, fmt.Sprintf("%s/%s/%s", realmRootPath, targetRealmName, userResourceName))
 
 }
 

--- a/keycloakClient/keycloakClient.go
+++ b/keycloakClient/keycloakClient.go
@@ -319,6 +319,29 @@ func (c *Client) post(accessToken string, data interface{}, url string) (string,
 	return location, nil
 
 }
+func (c *Client) postV2(accessToken string, data interface{}, url string) (string, error) {
+	path := c.apiURL.String() + url
+	buf := &bytes.Buffer{}
+	err := json.NewEncoder(buf).Encode(data)
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequest("POST", path, buf)
+	if err != nil {
+		return "", err
+	}
+	req, err = setAuthorizationAndHostHeaders(req, accessToken)
+	if err != nil {
+		return "", err
+	}
+	response, err := e3dbClients.ReturnRawServiceCall(c.httpClient, req, nil)
+	if err != nil {
+		return "", err
+	}
+	location := response.Header.Get("Location")
+	return location, nil
+
+}
 func (c *Client) postJSONWithToznySessionToken(accessToken string, data interface{}, url string, sessionToken string) (string, error) {
 	path := c.apiURL.String() + url
 	buf := &bytes.Buffer{}
@@ -1058,7 +1081,7 @@ func (c *Client) GetUserFederationProviderMapper(accessToken string, realmName, 
 // CreateUserFederationProviderMapper creates a user federation provider mapper for a realm for mapping attributes from
 // synced users from an external source, returning the location of the created provider mapper or error (if any).
 func (c *Client) CreateUserFederationProviderMapper(accessToken string, realmName string, userFederationProviderMapper UserFederationProviderMapperRepresentation) (string, error) {
-	return c.post(accessToken, userFederationProviderMapper, fmt.Sprintf("%s/%s/%s", realmRootPath, realmName, componentsResourceName))
+	return c.postV2(accessToken, userFederationProviderMapper, fmt.Sprintf("%s/%s/%s", realmRootPath, realmName, componentsResourceName))
 }
 
 // GetUserFederationProviderMappers returns a list of UserFederationProviderMappers belonging to the realm

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ type RequestError struct {
 	message    string
 	URL        string
 	StatusCode int
+	rawMessage string
 }
 
 // LoggingClient is used to log requests and timing based on configuration passed in
@@ -74,9 +75,17 @@ func (err *RequestError) Error() string {
 	return err.message
 }
 
+func (e *RequestError) RawMessage() string {
+	return e.rawMessage
+}
+
 // NewError creates a new RequestError
 func NewError(message, url string, statusCode int) error {
-	return &RequestError{message, url, statusCode}
+	return &RequestError{
+		message:    message,
+		URL:        url,
+		StatusCode: statusCode,
+	}
 }
 
 // MakeE3DBServiceCall attempts to call an e3db service by executing the provided request and deserializing the response into the provided result holder, returning error (if any).
@@ -197,16 +206,17 @@ func ReturnRawServiceCall(client request.Requester, req *http.Request, result in
 	if !(response.StatusCode >= 200 && response.StatusCode <= 299) {
 		requestURL := req.URL.String()
 		bodyBytes, readErr := io.ReadAll(response.Body)
-		message := fmt.Sprintf("e3db: %s: server http error %d", requestURL, response.StatusCode)
+		var rawMessage string
 
 		if readErr == nil && len(bodyBytes) > 0 {
-			message = string(bodyBytes)
+			rawMessage = string(bodyBytes)
 		}
 
 		return response, &RequestError{
 			StatusCode: response.StatusCode,
 			URL:        requestURL,
-			message:    message,
+			message:    fmt.Sprintf("e3db: %s: server http error %d", requestURL, response.StatusCode),
+			rawMessage: rawMessage,
 		}
 	}
 	// If no result is expected, don't attempt to decode a potentially

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -195,10 +196,17 @@ func ReturnRawServiceCall(client request.Requester, req *http.Request, result in
 	defer response.Body.Close()
 	if !(response.StatusCode >= 200 && response.StatusCode <= 299) {
 		requestURL := req.URL.String()
+		bodyBytes, readErr := io.ReadAll(response.Body)
+		message := fmt.Sprintf("e3db: %s: server http error %d", requestURL, response.StatusCode)
+
+		if readErr == nil && len(bodyBytes) > 0 {
+			message = string(bodyBytes)
+		}
+
 		return response, &RequestError{
 			StatusCode: response.StatusCode,
 			URL:        requestURL,
-			message:    fmt.Sprintf("e3db: %s: server http error %d", requestURL, response.StatusCode),
+			message:    message,
 		}
 	}
 	// If no result is expected, don't attempt to decode a potentially


### PR DESCRIPTION
Updated "ReturnRawServiceCall" method to return Keycloak error. Previously, when a downstream service return error, the response body was ignored(not read). 

Instead, it returns a error string with request URL and status text. 

Now, i have made a change to read response body and if it is not null then it will return the error response else fall back to the legacy error message.