### PR TITLE
Added endpoint for test case - update Record

### DIFF
--- a/storageClient/storageClient.go
+++ b/storageClient/storageClient.go
@@ -747,6 +747,17 @@ func (c *StorageClient) WriteRecord(ctx context.Context, params Record) (*Record
 	return result, err
 }
 
+func (c *StorageClient) UpdateRecord(ctx context.Context, recordId string, versionId string, params Record) (*Record, error) {
+	var result *Record
+	path := c.Host + storageServiceBasePath + "/records/safe/edit/" + recordId + "/" + versionId
+	req, err := e3dbClients.CreateRequest("POST", path, params)
+	if err != nil {
+		return result, err
+	}
+	err = e3dbClients.MakeE3DBServiceCall(ctx, c.requester, c.E3dbAuthClient.TokenSource(), req, &result)
+	return result, err
+}
+
 // WriteFile writes the pending files to the pending file table, returning a pendingFileID and pendingFileURL.
 // 'Compression' must be nonempty in params FileMeta, otherwise it will cause an error even though the error is not returned.
 func (c *StorageClient) WriteFile(ctx context.Context, params Record) (*PendingFileResponse, error) {


### PR DESCRIPTION
As part of migration, to test update record via handler, we added e3db endpoint.